### PR TITLE
Implement PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,16 +18,33 @@ on:
         required: false
         default: false
         type: boolean
+      platforms:
+        description: List of target platforms
+        required: false
+        default: 'ubuntu-20.04 windows-2019 macos-10.15'
+        type: string
 
 jobs:
 
+  generate_platform_matrix:
+    name: Generate build_wheels matrix
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.pure_python_wheel }}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          FILTER='split(" ") as $platforms | {"os": $platforms}'
+          echo "::set-output name=matrix::$( echo ${{ inputs.platforms }} | jq -R -c $FILTER )"
+
   build_wheels:
     name: Build platform-dependent wheels
+    needs: [generate_platform_matrix]
     runs-on: ${{ matrix.os }}
     if: ${{ !inputs.pure_python_wheel }}
     strategy:
-      matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+      matrix: ${{fromJSON(needs.generate_platform_matrix.outputs.matrix)}}
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,19 @@ on:
         required: false
         default: 'ubuntu-20.04 windows-2019 macos-10.15'
         type: string
+      upload_to_pypi:
+        description: Always upload to PyPI - if not, only upload tags
+        required: false
+        default: false
+        type: boolean
+      repository_url:
+        description: The PyPI repository URL to use
+        required: false
+        default: ''
+        type: string
+    secrets:
+      pypi_password:
+        required: false
 
 jobs:
 
@@ -56,6 +69,9 @@ jobs:
         env:
           CIBW_TEST_EXTRAS: ${{ inputs.test_extras }}
           CIBW_TEST_COMMAND: ${{ inputs.test_command }}
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*
 
   build_sdist:
     name: Build source distribution
@@ -68,6 +84,9 @@ jobs:
         with:
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*
 
   build_sdist_and_wheel:
     name: Build source and wheel distribution
@@ -80,3 +99,27 @@ jobs:
         with:
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
+          pure_python_wheel: ${{ inputs.pure_python_wheel }}
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*
+
+  upload_pypi:
+    name: Upload to PyPI
+    needs: [build_wheels, build_sdist, build_sdist_and_wheel]
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push'
+        && (startsWith(github.event.ref, 'refs/tags/v') | inputs.upload_to_pypi )
+        && (needs.build_wheels.result == 'success' || needs.build_wheels.result == 'skipped')
+        && (needs.build_sdist.result == 'success' || needs.build_sdist.result == 'skipped')
+        && (needs.build_sdist_and_wheel.result == 'success' || needs.build_sdist_and_wheel.result == 'skipped')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,16 +46,16 @@ jobs:
     strategy:
       matrix: ${{fromJSON(needs.generate_platform_matrix.outputs.matrix)}}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Run cibuildwheel
-      uses: pypa/cibuildwheel@v2.3.1
-      with:
-        output-dir: dist
-      env:
-        CIBW_TEST_EXTRAS: ${{ inputs.test_extras }}
-        CIBW_TEST_COMMAND: ${{ inputs.test_command }}
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run cibuildwheel
+        uses: pypa/cibuildwheel@v2.3.1
+        with:
+          output-dir: dist
+        env:
+          CIBW_TEST_EXTRAS: ${{ inputs.test_extras }}
+          CIBW_TEST_COMMAND: ${{ inputs.test_command }}
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Build and publish a Python package
+name: Build and publish Python package
 
 on:
   workflow_call:
@@ -14,7 +14,7 @@ on:
         default: ''
         type: string
       pure_python_wheel:
-        description: Whether to build a pure Python wheel - if not, separate wheels are built for each platform.
+        description: Whether to build a pure Python wheel - if not, separate wheels are built for each platform
         required: false
         default: false
         type: boolean
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: build
-        uses: OpenAstronomy/action-build-sdist-and-wheel@main
+        uses: OpenAstronomy/build-python-dist@main
         with:
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: build
-        uses: OpenAstronomy/action-build-sdist-and-wheel@main
+        uses: OpenAstronomy/build-python-dist@main
         with:
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}


### PR DESCRIPTION
The built matrix [can be parsed from JSON](https://docs.github.com/en/actions/learn-github-actions/expressions#example-returning-a-json-object) so having a separate job to create the build matrix should work. I experimented with allowing for more configuration of the CIBW env vars by parsing JSON, however, in my opinion it adds a lot of unnecessary complexity. In most cases cibuildwheel can be [configured in `pyproject.toml`](https://cibuildwheel.readthedocs.io/en/stable/options/#configuration-file). Using the configuration file would mean less to maintain in this repo.

At some point the `generate_platform_matrix` job may need modified if we want to allow for `aarch64` builds with the `hypriot/qemu-register` Docker image.