### PR TITLE
Implement tox testing

### DIFF
--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -3,22 +3,101 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test_pyos:
+    uses: ./.github/workflows/tox.yml
+    with:
+      envs: |
+        - linux: py310-inputs-linux
+        - macos: py39-inputs-macos
+        - windows: py38-inputs-windows
+          toxargs: '-v'
+
+        - linux: py310-inputs-conda
+        - macos: py310-inputs-conda
+          conda: false
+          posargs: not
+        - windows: py310-inputs-con_da
+          conda: true
+
+      pytest: false
+
+  test_global_override:
+    uses: ./.github/workflows/tox.yml
+    with:
+      conda: 'true'
+      toxdeps: 'astropy'
+      envs: |
+        - linux: py39-inputs-conda
+        - linux: py39-inputs-conda
+          conda: false
+          posargs: not
+        - linux: py39-inputs-con_da
+        - linux: py39-inputs-con_da
+          conda: auto
+          posargs: not
+
+        - linux: py39-inputs-toxdeps
+          posargs: astropy
+        - linux: py39-inputs-toxdeps
+          toxdeps: sunpy
+          posargs: sunpy
+
+      pytest: false
+
+  test_default_python:
+    uses: ./.github/workflows/tox.yml
+    with:
+      default_python: '3.7'
+      envs: |
+        - linux: default_python
+          posargs: '7'
+        - linux: default_python
+          default_python: '3.10'
+          posargs: '10'
+      pytest: false
+
+  test_libraries:
     uses: ./.github/workflows/tox.yml
     with:
       libraries: |
         apt:
-          - libopenjp2-7
+          - rolldice
         brew:
-          - openjpeg
+          - graphviz
+      envs: |
+        - linux: libraries
+          posargs: 'rolldice -v'
+        - macos: libraries
+          posargs: 'graphviz -V'
+        - linux: libraries
+          posargs: 'bcal -h'
+          libraries:
+            apt:
+              - bcal
+        - windows: libraries
+          posargs: 'graphviz -V'
+          libraries:
+            apt:
+              - shouldnotinstall12345
+            choco:
+              - graphviz
+      pytest: false
+
+  test_venv:
+    uses: ./.github/workflows/tox.yml
+    with:
       envs: |
         - linux: pep8
           name: style_check
           pytest: false
-        - macos: py37-test
-          posargs: -n=4
-          toxargs: -customarg
-        - windows: py36-docs
-          libraries:
-            choco:
-              - graphviz
+        - linux: py310
+        - macos: py39
+        - windows: py38
+
+  test_conda:
+    uses: ./.github/workflows/tox.yml
+    with:
+      envs: |
+        - linux: py310-conda
+        - macos: py39-conda
+        - windows: py38-conda

--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    uses: ./.github/workflows/tox.yml
+    with:
+      libraries: |
+        apt:
+          - libopenjpeg5
+        brew:
+          - openjpeg
+      envs: |
+        - linux: pep8
+          name: style_check
+          pytest: false
+        - macos: py37-test
+          posargs: -n=4
+          toxargs: -customarg
+        - windows: py36-docs
+          libraries:
+            choco:
+              - graphviz

--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -8,7 +8,7 @@ jobs:
     with:
       libraries: |
         apt:
-          - libopenjpeg5
+          - libopenjp2-7
         brew:
           - openjpeg
       envs: |

--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -25,23 +25,17 @@ jobs:
     uses: ./.github/workflows/tox.yml
     with:
       conda: 'true'
-      toxdeps: 'astropy'
       envs: |
+        # conda present in toxenv
         - linux: py39-inputs-conda
         - linux: py39-inputs-conda
           conda: false
           posargs: not
+        # conda not present in toxenv
         - linux: py39-inputs-con_da
         - linux: py39-inputs-con_da
           conda: auto
           posargs: not
-
-        - linux: py39-inputs-toxdeps
-          posargs: astropy
-        - linux: py39-inputs-toxdeps
-          toxdeps: sunpy
-          posargs: sunpy
-
       pytest: false
 
   test_default_python:
@@ -68,14 +62,14 @@ jobs:
         - linux: libraries
           posargs: 'rolldice -v'
         - macos: libraries
-          posargs: 'graphviz -V'
+          posargs: 'dot -V'
         - linux: libraries
           posargs: 'bcal -h'
           libraries:
             apt:
               - bcal
         - windows: libraries
-          posargs: 'graphviz -V'
+          posargs: 'dot -V'
           libraries:
             apt:
               - shouldnotinstall12345

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: ''
         type: string
+      toxdeps:
+        description: Tox dependencies
+        required: false
+        default: ''
+        type: string
       toxargs:
         description: Positional arguments for tox
         required: false
@@ -27,11 +32,35 @@ on:
         required: false
         default: true
         type: boolean
+      coverage:
+        description: Coverage providers to upload to
+        required: false
+        default: ''
+        type: string
+      conda:
+        description: Whether to test with conda
+        required: false
+        default: 'auto'
+        type: string
+      display:
+        description: Whether to setup a headless display
+        required: false
+        default: false
+        type: boolean
+      default_python:
+        description: Default version of Python
+        required: false
+        default: '3.x'
+        type: string
       submodules:
         description: Whether to checkout submodules
         required: false
         default: true
         type: boolean
+    secrets:
+      CODECOV_TOKEN:
+        description: Codecov upload token (for private repositories only)
+        required: false
 
 jobs:
 
@@ -52,7 +81,11 @@ jobs:
       - id: set-outputs
         run: |
           python tools/tox_matrix.py --envs "${{ inputs.envs }}" --libraries "${{ inputs.libraries }}" \
-          --posargs "${{ inputs.posargs }}" --toxargs "${{ inputs.toxargs }}" --pytest "${{ inputs.pytest }}"
+          --posargs "${{ inputs.posargs }}" --toxdeps "${{ inputs.toxdeps }}" \
+          --toxargs "${{ inputs.toxargs }}" --pytest "${{ inputs.pytest }}" \
+          --coverage "${{ inputs.coverage }}" --conda "${{ inputs.conda }}" \
+          --display "${{ inputs.display }}" \
+          --default-python "${{ inputs.default_python }}"
         shell: sh
 
   tox:
@@ -77,11 +110,33 @@ jobs:
           apt: ${{ matrix.libraries_apt }}
           choco: ${{ matrix.libraries_choco }}
 
-      - uses: actions/setup-python@v2
+      - name: Setup Python ${{ matrix.python_version }}
+        if: ${{ matrix.conda != 'true' }}
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: Run tox
-        run: |
-          echo python -m tox -e ${{ matrix.tox_env }} ${{ matrix.toxargs }} -- ${{ matrix.pytest_flag }} ${{ matrix.posargs }}
+      - name: Setup conda
+        if: ${{ matrix.conda == 'true' }}
+        uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          python-version: ${{ matrix.python_version }}
+
+      - name: Setup headless display
+        if: ${{ matrix.display == 'true' }}
+        uses: pyvista/setup-headless-display-action@v1
+
+      - name: Install tox
+        run: python -m pip install --upgrade tox ${{ matrix.toxdeps }}
         shell: sh
+
+      - name: Run tox
+        run: python -m tox -e ${{ matrix.tox_env }} ${{ matrix.toxargs }} -- ${{ matrix.pytest_flag }} ${{ matrix.posargs }}
+        shell: sh
+
+      - name: Upload to Codecov
+        if: ${{ contains(matrix.coverage, 'codecov') }}
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -132,7 +132,7 @@ jobs:
         shell: sh
 
       - name: Run tox
-        run: python -m tox -e ${{ matrix.tox_env }} ${{ matrix.toxargs }} -- ${{ matrix.pytest_flag }} ${{ matrix.posargs }}
+        run: python -m tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.pytest_flag }} ${{ matrix.posargs }}
         shell: sh
 
       - name: Upload to Codecov

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -60,7 +60,7 @@ jobs:
     needs: [envs]
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix: ${{fromJSON(needs.targets.outputs.matrix)}}
+      matrix: ${{fromJSON(needs.envs.outputs.matrix)}}
     steps:
 
       - uses: actions/checkout@v2

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -136,7 +136,7 @@ jobs:
         shell: sh
 
       - name: Upload to Codecov
-        if: ${{ contains(matrix.coverage, 'codecov') }}
+        if: ${{ contains(matrix.coverage, 'codecov') && matrix.pytest == 'true' }}
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -70,7 +70,7 @@ jobs:
           submodules: ${{ inputs.submodules }}
 
       - name: Install dependencies
-        uses: ConorMacBride/install-library@main
+        uses: ConorMacBride/install-package@main
         with:
           brew: ${{ matrix.libraries_brew }}
           brew-cask: ${{ matrix.libraries_brew_cask }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,87 @@
+name: Test Python package
+
+on:
+  workflow_call:
+    inputs:
+      envs:
+        description: Array of tox environments to test
+        required: true
+        type: string
+      libraries:
+        description: Additional packages to install
+        required: false
+        default: ''
+        type: string
+      posargs:
+        description: Positional arguments for pytest
+        required: false
+        default: ''
+        type: string
+      toxargs:
+        description: Positional arguments for tox
+        required: false
+        default: ''
+        type: string
+      pytest:
+        description: Whether pytest is run
+        required: false
+        default: true
+        type: boolean
+      submodules:
+        description: Whether to checkout submodules
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+
+  envs:
+    name: Load tox environments
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-outputs.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      # Uncomment before merging
+      #        with:
+      #           repository: 'OpenAstronomy/github-actions-workflows'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - run: python -m pip install PyYAML click
+      - id: set-outputs
+        run: |
+          python tools/tox_matrix.py --envs "${{ inputs.envs }}" --libraries "${{ inputs.libraries }}" \
+          --posargs "${{ inputs.posargs }}" --toxargs "${{ inputs.toxargs }}" --pytest "${{ inputs.pytest }}"
+        shell: sh
+
+  tox:
+    name: ${{ matrix.name }} (${{ matrix.os }})
+    needs: [envs]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{fromJSON(needs.targets.outputs.matrix)}}
+    steps:
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
+          submodules: ${{ inputs.submodules }}
+
+      - name: Install dependencies
+        uses: ConorMacBride/install-library@main
+        with:
+          brew: ${{ matrix.libraries_brew }}
+          brew-cask: ${{ matrix.libraries_brew_cask }}
+          apt: ${{ matrix.libraries_apt }}
+          choco: ${{ matrix.libraries_choco }}
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Run tox
+        run: |
+          echo python -m tox -e ${{ matrix.tox_env }} ${{ matrix.toxargs }} -- ${{ matrix.pytest_flag }} ${{ matrix.posargs }}
+        shell: sh

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -71,9 +71,8 @@ jobs:
       matrix: ${{ steps.set-outputs.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      # Uncomment before merging
-      #        with:
-      #           repository: 'OpenAstronomy/github-actions-workflows'
+        with:
+          repository: 'OpenAstronomy/github-actions-workflows'
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ on:
         default: ''
         type: string
       posargs:
-        description: Positional arguments for pytest
+        description: Positional arguments for the underlying tox test command
         required: false
         default: ''
         type: string

--- a/README.md
+++ b/README.md
@@ -2,6 +2,169 @@
 
 Reusable workflows for GitHub Actions.
 
+- [Test a Python package using tox](#test-a-python-package-using-tox)
+- [Build and publish a Python package](#build-and-publish-a-python-package)
+- [Build and publish a pure Python package](#build-and-publish-a-pure-python-package)
+
+## Test a Python package using tox
+
+This workflow makes it easy to map tox environments to GitHub Actions jobs.
+To use this template, your repository will need to have a `tox.ini` file.
+
+```yaml
+jobs:
+  publish:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    with:
+      posargs: '-n 4'
+      envs: |
+        - linux: pep8
+          pytest: false
+        - macos: py310
+        - windows: py39-docs
+          libraries:
+            choco:
+              - graphviz
+      coverage: 'codecov'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+```
+
+### Inputs
+
+A specification of tox environments must be passed to the `envs` input.
+There are a number of other inputs.
+All of these inputs (except `submodules`) can also be specified under each tox environment to overwrite the global value.
+
+In the following example `test1` will pass `--arg-local` to pytest, while `test2` will pass `--arg-global` to pytest,
+```yaml
+uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+with:
+  posargs: '--arg-global'
+  envs: |
+    - linux: test1
+      posargs: '--arg-local'
+    - linux: test2
+```
+
+#### envs
+Array of tox environments to test.
+Required input.
+
+```yaml
+uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+with:
+  envs: |
+    - <os>: <toxenv>
+    - <os>: <toxenv>
+```
+
+where `<os>` is the either `linux`, `macos` or `windows`, and `<toxenv>` is the name of the tox environment to run.
+
+***Note:** `envs` is a **string** and must be specified as a literal block scalar using the `|`. (Without the `|`, it must also be valid YAML.)*
+
+Example:
+
+```yaml
+uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+with:
+  envs: |
+    - linux: pep8
+    - linux: py39
+    - macos: py38-docs
+      name: build_docs
+    - windows: py310-conda
+```
+
+The name of the GitHub Actions job can be changed with the `name` option as shown above.
+By default, `name` will be the name of the tox environment.
+
+#### libraries
+Additional packages to install using apt (only on Linux), brew and brew cask (only on macOS), and choco (only on Windows).
+
+Global definition:
+```yaml
+uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+with:
+  libraries: |
+    apt:
+      - package1
+      - package2
+    brew:
+      - package3
+    brew-cask:
+      - package4
+    choco:
+      - package5
+```
+
+***Note:** `libraries` is a **string** and must be specified as a literal block scalar using the `|`. (Without the `|`, it must also be valid YAML.)*
+
+`envs` definition:
+```yaml
+with:
+  envs: |
+    - linux: py39
+      libraries:
+        apt:
+          - package1
+```
+
+#### posargs
+Positional arguments for the `{posargs}` replacement in an underlying test command within tox.
+Default is none.
+
+#### toxdeps
+Additional tox dependencies.
+This string is included at the end of the `pip install` command when installing tox.
+Default is none.
+
+#### toxargs
+Positional arguments for tox.
+Default is none.
+
+#### pytest
+Whether pytest is run by the tox environment.
+This determines if additional pytest positional arguments should be passed to tox.
+These arguments are to assist with saving test coverage reports.
+Default is `true`.
+
+Coverage will not be uploaded if this is `false`.
+
+#### coverage
+A space separated list of coverage providers to upload to.
+Currently only `codecov` is supported.
+Default is to not upload coverage reports.
+
+See also, `CODECOV_TOKEN` secret.
+
+#### conda
+Whether to test within a conda environment using `tox-conda`.
+Options are `'auto'` (default), `'true'` and `'false'`.
+
+If `'auto'`, conda will be used if the tox environment names contains "conda".
+For example, `'auto'` would enable conda for tox environments named `py39-conda`, `conda-test` or even `py38-secondary`.
+
+#### display
+Whether to setup a headless display.
+This uses the `pyvista/setup-headless-display-action@v1` GitHub Action.
+Default is `false`.
+
+#### default_python
+The version of Python to use if the tox environment name does not start with `py(2|3)[0-9]+`.
+Default is `3.x`.
+
+For example, a tox environment `py39-docs` will run on Python 3.9, while a tox environment `build_docs` will refer to the value of `default_python`. 
+
+#### submodules
+Whether to checkout submodules.
+Default is `true`.
+
+### Secrets
+
+#### CODECOV_TOKEN
+If your repository is private, in order to upload to Codecov you need to set the `CODECOV_TOKEN` environment variable or pass it as a secret to the workflow.
+
 ## Build and publish a Python package
 
 Build, test and publish a Python source distribution and collection of platform-dependent wheels.

--- a/test_package/__init__.py
+++ b/test_package/__init__.py
@@ -1,1 +1,3 @@
 from . import simple
+
+__all__ = ["simple"]

--- a/tools/tox_matrix.py
+++ b/tools/tox_matrix.py
@@ -100,10 +100,10 @@ def get_matrix_item(env, global_libraries, global_string_parameters,
         major, minor = m.groups()
         item["python_version"] = f"{major}.{minor}"
     else:
-        item["python_version"] = default_python
+        item["python_version"] = env.get("default_python") or default_python
 
     # set name
-    item["name"] = env.get("name", False) or item["toxenv"]
+    item["name"] = env.get("name") or item["toxenv"]
 
     # set pytest_flag
     if item["pytest"] == "true":

--- a/tools/tox_matrix.py
+++ b/tools/tox_matrix.py
@@ -22,8 +22,8 @@ MACHINE_TYPE = {
 @click.option("--conda", default="auto")
 @click.option("--display", default="false")
 @click.option("--default-python", default="")
-def load_tox_targets(envs, libraries, posargs, toxdeps, toxargs, pytest, coverage,
-                     conda, display, default_python):
+def load_tox_targets(envs, libraries, posargs, toxdeps, toxargs, pytest,
+                     coverage, conda, display, default_python):
     """Script to load tox targets for GitHub Actions workflow."""
     # Load envs config
     envs = yaml.load(envs, Loader=yaml.BaseLoader)
@@ -55,17 +55,20 @@ def load_tox_targets(envs, libraries, posargs, toxdeps, toxargs, pytest, coverag
     # Create matrix
     matrix = {"include": []}
     for env in envs:
-        matrix["include"].append(
-            get_matrix_item(env, global_libraries=global_libraries, global_string_parameters=string_parameters,
-                            default_python=default_python)
-        )
+        matrix["include"].append(get_matrix_item(
+            env,
+            global_libraries=global_libraries,
+            global_string_parameters=string_parameters,
+            default_python=default_python,
+        ))
 
     # Output matrix
     print(json.dumps(matrix, indent=2))
     print(f"::set-output name=matrix::{json.dumps(matrix)}")
 
 
-def get_matrix_item(env, global_libraries, global_string_parameters, default_python):
+def get_matrix_item(env, global_libraries, global_string_parameters,
+                    default_python):
 
     # define spec for each matrix include (+ global_string_parameters)
     item = {
@@ -104,12 +107,10 @@ def get_matrix_item(env, global_libraries, global_string_parameters, default_pyt
 
     # set pytest_flag
     if item["pytest"] == "true":
-        if platform == "windows":
-            item["pytest_flag"] = (r"--junitxml=junit\test-results.xml "
-                                   r"--cov-report=xml:${GITHUB_WORKSPACE}\coverage.xml")
-        else:
-            item["pytest_flag"] = (r"--junitxml=junit/test-results.xml "
-                                   r"--cov-report=xml:${GITHUB_WORKSPACE}/coverage.xml")
+        sep = "\\" if platform == "windows" else "/"
+        item["pytest_flag"] = (
+            rf"--junitxml=junit{sep}test-results.xml "
+            rf"--cov-report=xml:${{GITHUB_WORKSPACE}}{sep}coverage.xml")
     else:
         item["pytest_flag"] = ""
 

--- a/tools/tox_matrix.py
+++ b/tools/tox_matrix.py
@@ -93,7 +93,7 @@ def get_matrix_item(env, global_libraries, global_posargs, global_toxargs, globa
     if pytest:
         if platform == "windows":
             item["pytest_flag"] = (r"--junitxml=junit\test-results.xml "
-                                   r"--cov-report=xml:${Env:GITHUB_WORKSPACE}\coverage.xml")
+                                   r"--cov-report=xml:${GITHUB_WORKSPACE}\coverage.xml")
         else:
             item["pytest_flag"] = (r"--junitxml=junit/test-results.xml "
                                    r"--cov-report=xml:${GITHUB_WORKSPACE}/coverage.xml")

--- a/tools/tox_matrix.py
+++ b/tools/tox_matrix.py
@@ -10,16 +10,20 @@ MACHINE_TYPE = {
     "windows": "windows-2019",
 }
 
-DEFAULT_PYTHON = "3.x"
-
 
 @click.command()
 @click.option("--envs", default="")
 @click.option("--libraries", default="")
 @click.option("--posargs", default="")
+@click.option("--toxdeps", default="")
 @click.option("--toxargs", default="")
-@click.option("--pytest", default="")
-def load_tox_targets(envs, libraries, posargs, toxargs, pytest):
+@click.option("--pytest", default="true")
+@click.option("--coverage", default="")
+@click.option("--conda", default="auto")
+@click.option("--display", default="false")
+@click.option("--default-python", default="")
+def load_tox_targets(envs, libraries, posargs, toxdeps, toxargs, pytest, coverage,
+                     conda, display, default_python):
     """Script to load tox targets for GitHub Actions workflow."""
     # Load envs config
     envs = yaml.load(envs, Loader=yaml.BaseLoader)
@@ -37,12 +41,22 @@ def load_tox_targets(envs, libraries, posargs, toxargs, pytest):
         global_libraries.update(libraries)
     print(json.dumps(global_libraries, indent=2))
 
+    # Default string parameters which can be overwritten by each env
+    string_parameters = {
+        "posargs": posargs,
+        "toxdeps": toxdeps,
+        "toxargs": toxargs,
+        "coverage": coverage,
+        "conda": conda,
+        "display": display,
+    }
+
     # Create matrix
     matrix = {"include": []}
     for env in envs:
         matrix["include"].append(
-            get_matrix_item(env, global_libraries=global_libraries, global_posargs=posargs,
-                            global_toxargs=toxargs, global_pytest=pytest)
+            get_matrix_item(env, global_libraries=global_libraries, global_string_parameters=string_parameters,
+                            global_pytest=pytest, default_python=default_python)
         )
 
     # Output matrix
@@ -50,22 +64,23 @@ def load_tox_targets(envs, libraries, posargs, toxargs, pytest):
     print(f"::set-output name=matrix::{json.dumps(matrix)}")
 
 
-def get_matrix_item(env, global_libraries, global_posargs, global_toxargs, global_pytest):
+def get_matrix_item(env, global_libraries, global_string_parameters, global_pytest, default_python):
 
-    # define spec for each matrix include
+    # define spec for each matrix include (+ global_string_parameters)
     item = {
         "os": None,
         "toxenv": None,
         "python_version": None,
         "name": None,
         "pytest_flag": None,
-        "toxargs": None,
-        "posargs": None,
         "libraries_brew": None,
         "libraries_brew_cask": None,
         "libraries_apt": None,
         "libraries_choco": None,
     }
+    for string_param, default in global_string_parameters.items():
+        env_value = env.get(string_param)
+        item[string_param] = default if env_value is None else env_value
 
     # set os and toxenv
     for k, v in MACHINE_TYPE.items():
@@ -81,7 +96,7 @@ def get_matrix_item(env, global_libraries, global_posargs, global_toxargs, globa
         major, minor = m.groups()
         item["python_version"] = f"{major}.{minor}"
     else:
-        item["python_version"] = DEFAULT_PYTHON
+        item["python_version"] = default_python
 
     # set name
     item["name"] = env.get("name", False) or item["toxenv"]
@@ -100,14 +115,6 @@ def get_matrix_item(env, global_libraries, global_posargs, global_toxargs, globa
     else:
         item["pytest_flag"] = ""
 
-    # set toxargs
-    env_toxargs = env.get("toxargs")
-    item["toxargs"] = global_toxargs if env_toxargs is None else env_toxargs
-
-    # set posargs
-    env_posargs = env.get("posargs")
-    item["posargs"] = global_posargs if env_posargs is None else env_posargs
-
     # set libraries
     env_libraries = env.get("libraries")
     libraries = global_libraries if env_libraries is None else env_libraries
@@ -115,6 +122,18 @@ def get_matrix_item(env, global_libraries, global_posargs, global_toxargs, globa
     item["libraries_brew_cask"] = " ".join(libraries.get("brew_cask", []))
     item["libraries_apt"] = " ".join(libraries.get("apt", []))
     item["libraries_choco"] = " ".join(libraries.get("choco", []))
+
+    # set "auto" conda value
+    if item["conda"] == "auto":
+        item["conda"] = "true" if "conda" in item["toxenv"] else "false"
+
+    # inject toxdeps for conda
+    if item["conda"] == "true" and "tox-conda" not in item["toxdeps"].lower():
+        item["toxdeps"] = ("tox-conda " + item["toxdeps"]).strip()
+
+    # verify values
+    assert item["conda"] in {"true", "false"}
+    assert item["display"] in {"true", "false"}
 
     return item
 

--- a/tools/tox_matrix.py
+++ b/tools/tox_matrix.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 
 import click
@@ -94,10 +93,10 @@ def get_matrix_item(env, global_libraries, global_posargs, global_toxargs, globa
     if pytest:
         if platform == "windows":
             item["pytest_flag"] = (r"--junitxml=junit\test-results.xml "
-                                   rf"--cov-report=xml:{os.getenv('GITHUB_WORKSPACE')}\coverage.xml")
+                                   r"--cov-report=xml:${Env:GITHUB_WORKSPACE}\coverage.xml")
         else:
             item["pytest_flag"] = (r"--junitxml=junit/test-results.xml "
-                                   rf"--cov-report=xml:{os.getenv('GITHUB_WORKSPACE')}/coverage.xml")
+                                   r"--cov-report=xml:${GITHUB_WORKSPACE}/coverage.xml")
     else:
         item["pytest_flag"] = ""
 

--- a/tools/tox_matrix.py
+++ b/tools/tox_matrix.py
@@ -1,0 +1,124 @@
+import json
+import os
+import re
+
+import click
+import yaml
+
+MACHINE_TYPE = {
+    "linux": "ubuntu-20.04",
+    "macos": "macos-10.15",
+    "windows": "windows-2019",
+}
+
+DEFAULT_PYTHON = "3.x"
+
+
+@click.command()
+@click.option("--envs", default="")
+@click.option("--libraries", default="")
+@click.option("--posargs", default="")
+@click.option("--toxargs", default="")
+@click.option("--pytest", default="")
+def load_tox_targets(envs, libraries, posargs, toxargs, pytest):
+    """Script to load tox targets for GitHub Actions workflow."""
+    # Load envs config
+    envs = yaml.load(envs, Loader=yaml.BaseLoader)
+    print(json.dumps(envs, indent=2))
+
+    # Load global libraries config
+    global_libraries = {
+        "brew": [],
+        "brew-cask": [],
+        "apt": [],
+        "choco": [],
+    }
+    libraries = yaml.load(libraries, Loader=yaml.BaseLoader)
+    if libraries is not None:
+        global_libraries.update(libraries)
+    print(json.dumps(global_libraries, indent=2))
+
+    # Create matrix
+    matrix = {"include": []}
+    for env in envs:
+        matrix["include"].append(
+            get_matrix_item(env, global_libraries=global_libraries, global_posargs=posargs,
+                            global_toxargs=toxargs, global_pytest=pytest)
+        )
+
+    # Output matrix
+    print(json.dumps(matrix, indent=2))
+    print(f"::set-output name=matrix::{json.dumps(matrix)}")
+
+
+def get_matrix_item(env, global_libraries, global_posargs, global_toxargs, global_pytest):
+
+    # define spec for each matrix include
+    item = {
+        "os": None,
+        "toxenv": None,
+        "python_version": None,
+        "name": None,
+        "pytest_flag": None,
+        "toxargs": None,
+        "posargs": None,
+        "libraries_brew": None,
+        "libraries_brew_cask": None,
+        "libraries_apt": None,
+        "libraries_choco": None,
+    }
+
+    # set os and toxenv
+    for k, v in MACHINE_TYPE.items():
+        if k in env:
+            platform = k
+            item["os"] = v
+            item["toxenv"] = env[k]
+    assert item["os"] is not None and item["toxenv"] is not None
+
+    # set python_version
+    m = re.search("^py(2|3)([0-9]+)", item["toxenv"])
+    if m is not None:
+        major, minor = m.groups()
+        item["python_version"] = f"{major}.{minor}"
+    else:
+        item["python_version"] = DEFAULT_PYTHON
+
+    # set name
+    item["name"] = env.get("name", False) or item["toxenv"]
+
+    # set pytest_flag
+    env_pytest = env.get("pytest")
+    pytest = global_pytest if env_pytest is None else env_pytest
+    pytest = str(pytest).lower() == "true"
+    if pytest:
+        if platform == "windows":
+            item["pytest_flag"] = (r"--junitxml=junit\test-results.xml "
+                                   rf"--cov-report=xml:{os.getenv('GITHUB_WORKSPACE')}\coverage.xml")
+        else:
+            item["pytest_flag"] = (r"--junitxml=junit/test-results.xml "
+                                   rf"--cov-report=xml:{os.getenv('GITHUB_WORKSPACE')}/coverage.xml")
+    else:
+        item["pytest_flag"] = ""
+
+    # set toxargs
+    env_toxargs = env.get("toxargs")
+    item["toxargs"] = global_toxargs if env_toxargs is None else env_toxargs
+
+    # set posargs
+    env_posargs = env.get("posargs")
+    item["posargs"] = global_posargs if env_posargs is None else env_posargs
+
+    # set libraries
+    env_libraries = env.get("libraries")
+    libraries = global_libraries if env_libraries is None else env_libraries
+    item["libraries_brew"] = " ".join(libraries.get("brew", []))
+    item["libraries_brew_cask"] = " ".join(libraries.get("brew_cask", []))
+    item["libraries_apt"] = " ".join(libraries.get("apt", []))
+    item["libraries_choco"] = " ".join(libraries.get("choco", []))
+
+    return item
+
+
+if __name__ == "__main__":
+    load_tox_targets()

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     pep8
     py3{8,9,10}
-    py3{8,9,10}-inputs-{linux,macos,windows,conda,con_da,toxdeps}
+    py3{8,9,10}-inputs-{linux,macos,windows,conda,con_da}
     default_python
     libraries
 
@@ -25,8 +25,6 @@ commands =
     # Check is conda is being used
     !conda-!con_da: python -c "import os, sys; assert not os.path.exists(os.path.join(sys.prefix, 'conda-meta', 'history'))"
     conda,con_da: python -c "import os, sys; assert {posargs} os.path.exists(os.path.join(sys.prefix, 'conda-meta', 'history'))"
-    # Check that toxdeps installed the expected package
-    toxdeps: python -c "import {posargs}"
     # Run a command that should only succeed is the library is installed
     libraries: {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,46 @@
+[tox]
+envlist =
+    pep8
+    py3{8,9,10}
+    py3{8,9,10}-inputs-{linux,macos,windows,conda,con_da,toxdeps}
+    default_python
+    libraries
+
+[testenv]
+whitelist_externals =
+    python
+    conda
+skip_install = true
+commands =
+    # Check the python version is as expected
+    python -c "import sys; assert sys.version_info.major == 3"
+    py38: python -c "import sys; assert sys.version_info.minor == 8"
+    py39: python -c "import sys; assert sys.version_info.minor == 9"
+    py310: python -c "import sys; assert sys.version_info.minor == 10"
+    default_python: python -c "import sys; assert sys.version_info.minor == {posargs}"
+    # Check the OS is as expected
+    linux: python -c "import platform; assert platform.system() == 'Linux'"
+    macos: python -c "import platform; assert platform.system() == 'Darwin'"
+    windows: python -c "import platform; assert platform.system() == 'Windows'"
+    # Check is conda is being used
+    !conda-!con_da: python -c "import os, sys; assert not os.path.exists(os.path.join(sys.prefix, 'conda-meta', 'history'))"
+    conda,con_da: python -c "import os, sys; assert {posargs} os.path.exists(os.path.join(sys.prefix, 'conda-meta', 'history'))"
+    # Check that toxdeps installed the expected package
+    toxdeps: python -c "import {posargs}"
+    # Run a command that should only succeed is the library is installed
+    libraries: {posargs}
+
+[testenv:pep8]
+description = verify pep8
+deps = flake8
+commands = flake8 . --count
+
+[testenv:py3{8,9,10}{,-conda}]
+description = run pytest
+skip_install = false
+extras = test
+conda_deps = pytest
+commands =
+    conda: python -c "import os, sys; assert os.path.exists(os.path.join(sys.prefix, 'conda-meta', 'history'))"
+    conda: conda list
+    pytest --pyargs test_package


### PR DESCRIPTION
Similar to the publish workflow, a Python script is used to create the matrix of tox environments. While it's not ideal to have to use a Python script to configure the CI pipeline, it does offer a lot of flexibility and makes it much easier to implement new options. We could even test this Python script itself.

I've create a composite action (https://github.com/ConorMacBride/install-package) to replace https://github.com/OpenAstronomy/azure-pipelines-templates/blob/master/install-libraries.yml. It's used in both the publish and tox workflows. This can be moved to the OpenAstronomy org if you like.

Have a look at `test_tox.yml` and let me know what you think of how the workflow is configured. I've tried to keep it similar to the Azure Pipelines tox template, but there are still a lot of key features to add -- including actually running tox!