### PR TITLE
Update how upload_to_pypi is defined

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,7 +144,7 @@ jobs:
     if: |
       always() &&
       needs.targets.result == 'success' &&
-      needs.targets.outputs.upload_to_pypi &&
+      needs.targets.outputs.upload_to_pypi == 'true' &&
       needs.build_wheels.result != 'failure' &&
       needs.build_sdist.result != 'failure'
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,9 @@ on:
         default: ''
         type: string
       upload_to_pypi:
-        description: Always upload to PyPI after successful builds - if false, only upload when pushing tags
+        description: A condition specifying whether to upload to PyPI
         required: false
-        default: false
+        default: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))
         type: boolean
       repository_url:
         description: The PyPI repository URL to use
@@ -130,7 +130,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: |
-      (( github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')) || inputs.upload_to_pypi ) &&
+      inputs.upload_to_pypi &&
       needs.build_wheels.result != 'failure' && needs.build_sdist.result != 'failure'
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,12 +139,14 @@ jobs:
 
   upload_pypi:
     name: Upload to PyPI
-    needs: [build_wheels, build_sdist]
+    needs: [targets, build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: |
       always() &&
+      needs.targets.result == 'success' &&
       needs.targets.outputs.upload_to_pypi &&
-      needs.build_wheels.result != 'failure' && needs.build_sdist.result != 'failure'
+      needs.build_wheels.result != 'failure' &&
+      needs.build_sdist.result != 'failure'
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,6 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       inputs.upload_to_pypi &&
+      always() &&
       needs.build_wheels.result != 'failure' && needs.build_sdist.result != 'failure'
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,8 @@ on:
       upload_to_pypi:
         description: A condition specifying whether to upload to PyPI
         required: false
-        default: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))
-        type: boolean
+        default: 'refs/tags/v'
+        type: string
       repository_url:
         description: The PyPI repository URL to use
         required: false
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-outputs.outputs.matrix }}
+      upload_to_pypi: ${{ steps.set-upload.outputs.upload_to_pypi }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -69,6 +70,17 @@ jobs:
       - id: set-outputs
         run: python tools/load_build_targets.py --targets "${{ inputs.targets }}"
         shell: sh
+      - id: set-upload
+        run: |
+          if [ $UPLOAD_TO_PYPI == "true" ] || [ $UPLOAD_TAG == "true" ];
+          then
+            echo "::set-output name=upload_to_pypi::true"
+          else
+            echo "::set-output name=upload_to_pypi::false"
+          fi
+        env:
+          UPLOAD_TO_PYPI: ${{ inputs.upload_to_pypi }}
+          UPLOAD_TAG: ${{ startsWith(inputs.upload_to_pypi, 'refs/tags/') && github.event_name == 'push' && startsWith(github.event.ref, inputs.upload_to_pypi) }}
 
   build_wheels:
     name: Build ${{ matrix.target }} wheels
@@ -130,8 +142,8 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: |
-      inputs.upload_to_pypi &&
       always() &&
+      needs.targets.outputs.upload_to_pypi &&
       needs.build_wheels.result != 'failure' && needs.build_sdist.result != 'failure'
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -72,7 +72,7 @@ jobs:
           UPLOAD_TAG: ${{ startsWith(inputs.upload_to_pypi, 'refs/tags/') && github.event_name == 'push' && startsWith(github.event.ref, inputs.upload_to_pypi) }}
       - uses: pypa/gh-action-pypi-publish@master
         name: Upload to PyPI
-        if: ${{ steps.set-upload.outputs.upload_to_pypi }}
+        if: ${{ steps.set-upload.outputs.upload_to_pypi == 'true' }}
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -19,9 +19,9 @@ on:
         default: ''
         type: string
       upload_to_pypi:
-        description: Always upload to PyPI after successful builds - if false, only upload when pushing tags
+        description: A condition specifying whether to upload to PyPI
         required: false
-        default: false
+        default: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))
         type: boolean
       repository_url:
         description: The PyPI repository URL to use

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -21,8 +21,8 @@ on:
       upload_to_pypi:
         description: A condition specifying whether to upload to PyPI
         required: false
-        default: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))
-        type: boolean
+        default: 'refs/tags/v'
+        type: string
       repository_url:
         description: The PyPI repository URL to use
         required: false
@@ -59,9 +59,20 @@ jobs:
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
           pure_python_wheel: true
+      - id: set-upload
+        run: |
+          if [ $UPLOAD_TO_PYPI == "true" ] || [ $UPLOAD_TAG == "true" ];
+          then
+            echo "::set-output name=upload_to_pypi::true"
+          else
+            echo "::set-output name=upload_to_pypi::false"
+          fi
+        env:
+          UPLOAD_TO_PYPI: ${{ inputs.upload_to_pypi }}
+          UPLOAD_TAG: ${{ startsWith(inputs.upload_to_pypi, 'refs/tags/') && github.event_name == 'push' && startsWith(github.event.ref, inputs.upload_to_pypi) }}
       - uses: pypa/gh-action-pypi-publish@master
         name: Upload to PyPI
-        if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')) || inputs.upload_to_pypi
+        if: ${{ steps.set-upload.outputs.upload_to_pypi }}
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}

--- a/README.md
+++ b/README.md
@@ -262,9 +262,11 @@ Packages needed to build the source distribution for testing. Must be a string o
 Default is install nothing extra.
 
 #### upload_to_pypi
-Whether to always upload to PyPI after successful builds.
-If `false`, successful builds are only uploaded when tags are pushed.
-Default is `false`.
+A boolean indicating whether to upload to PyPI after successful builds. This defaults to
+``(github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))``,
+meaning that packages are only uploaded to PyPI when a tag starting with ``v`` is
+pushed. This can be set to a different condition, or ``true`` to always upload packages
+and ``false`` to never upload them.
 
 #### repository_url
 The PyPI repository URL to use.
@@ -310,9 +312,11 @@ Packages needed to build the source distribution for testing. Must be a string o
 Default is install nothing extra.
 
 #### upload_to_pypi
-Whether to always upload to PyPI after successful builds.
-If `false`, successful builds are only uploaded when tags are pushed.
-Default is `false`.
+A boolean indicating whether to upload to PyPI after successful builds. This defaults to
+``(github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))``,
+meaning that packages are only uploaded to PyPI when a tag starting with ``v`` is
+pushed. This can be set to a different condition, or ``true`` to always upload packages
+and ``false`` to never upload them.
 
 #### repository_url
 The PyPI repository URL to use.

--- a/README.md
+++ b/README.md
@@ -262,11 +262,14 @@ Packages needed to build the source distribution for testing. Must be a string o
 Default is install nothing extra.
 
 #### upload_to_pypi
-A boolean indicating whether to upload to PyPI after successful builds. This defaults to
-``(github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))``,
-meaning that packages are only uploaded to PyPI when a tag starting with ``v`` is
-pushed. This can be set to a different condition, or ``true`` to always upload packages
-and ``false`` to never upload them.
+Whether to upload to PyPI after successful builds.
+The default is to upload to PyPI when tags that start with `v` are pushed.
+A boolean can be passed as `true` (always upload) or `false` (never upload)
+either explicitly or as a boolean expression (`${{ <expression> }}`).
+
+Alternatively, a string can be passed to match the start of a tag ref.
+For example, `'refs/tags/v'` (default) will upload tags that begin with `v`,
+and `'refs/tags/'` will upload on all pushed tags.
 
 #### repository_url
 The PyPI repository URL to use.
@@ -312,11 +315,14 @@ Packages needed to build the source distribution for testing. Must be a string o
 Default is install nothing extra.
 
 #### upload_to_pypi
-A boolean indicating whether to upload to PyPI after successful builds. This defaults to
-``(github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))``,
-meaning that packages are only uploaded to PyPI when a tag starting with ``v`` is
-pushed. This can be set to a different condition, or ``true`` to always upload packages
-and ``false`` to never upload them.
+Whether to upload to PyPI after successful builds.
+The default is to upload to PyPI when tags that start with `v` are pushed.
+A boolean can be passed as `true` (always upload) or `false` (never upload)
+either explicitly or as a boolean expression (`${{ <expression> }}`).
+
+Alternatively, a string can be passed to match the start of a tag ref.
+For example, `'refs/tags/v'` (default) will upload tags that begin with `v`,
+and `'refs/tags/'` will upload on all pushed tags.
 
 #### repository_url
 The PyPI repository URL to use.


### PR DESCRIPTION
Prior to this PR, I think upload_to_pypi was potentially counter-intuitive because upload_to_pypi: false still means that sometimes things are uploaded to PyPI. I think it would be cleaner to simply specify that it is a boolean condition for the upload, defaulting to true if a v* tag is pushed.

I'm not sure if this will work though, as I don't know if a condition can be given as the default for the parameter. But I do think we should try and make it behave somehow like it is here, meaning that upload_to_pypi: false would never upload anything.