### PR TITLE
Fix error when overriding global libraries with empty string

### DIFF
--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -75,6 +75,10 @@ jobs:
               - shouldnotinstall12345
             choco:
               - graphviz
+        # test no libraries override
+        - linux: libraries
+          libraries: ''
+          posargs: 'rolldice -v && exit 1 || exit 0'
       pytest: false
 
   test_venv:

--- a/tools/tox_matrix.py
+++ b/tools/tox_matrix.py
@@ -116,6 +116,8 @@ def get_matrix_item(env, global_libraries, global_string_parameters,
 
     # set libraries
     env_libraries = env.get("libraries")
+    if isinstance(env_libraries, str) and len(env_libraries.strip()) == 0:
+        env_libraries = {}  # no libraries requested for environment
     libraries = global_libraries if env_libraries is None else env_libraries
     for manager in ["brew", "brew_cask", "apt", "choco"]:
         item[f"libraries_{manager}"] = " ".join(libraries.get(manager, []))


### PR DESCRIPTION
It is documented that you can do `libraries: ''` to not install any libraries in a particular tox environment:
```yaml
uses: ./.github/workflows/tox.yml
with:
  libraries: |
    apt:
      - package
  envs: |
    - linux: py10
    - linux: docs
      libraries: ''
```
However, as realised at https://github.com/sunpy/sunpy/pull/5939, that empty string needs to be converted to an empty dictionary inside the Python script. I've also added a test for this case.