### PR TITLE
Add env vars for changing runner images

### DIFF
--- a/tools/load_build_targets.py
+++ b/tools/load_build_targets.py
@@ -5,9 +5,9 @@ import click
 import yaml
 
 MACHINE_TYPE = {
-    "linux": "ubuntu-latest",
-    "macos": "macos-latest",
-    "windows": "windows-latest",
+    "linux": os.environ.get("OA_LINUX_RUNNER", "ubuntu-latest"),
+    "macos": os.environ.get("OA_MACOS_RUNNER", "macos-latest"),
+    "windows": os.environ.get("OA_WINDOWS_RUNNER", "windows-latest"),
 }
 
 CIBW_BUILD = os.environ.get("CIBW_BUILD", "*")

--- a/tools/tox_matrix.py
+++ b/tools/tox_matrix.py
@@ -1,3 +1,4 @@
+import os
 import json
 import re
 
@@ -5,9 +6,9 @@ import click
 import yaml
 
 MACHINE_TYPE = {
-    "linux": "ubuntu-latest",
-    "macos": "macos-latest",
-    "windows": "windows-latest",
+    "linux": os.environ.get("OA_LINUX_RUNNER", "ubuntu-latest"),
+    "macos": os.environ.get("OA_MACOS_RUNNER", "macos-latest"),
+    "windows": os.environ.get("OA_WINDOWS_RUNNER", "windows-latest"),
 }
 
 


### PR DESCRIPTION
This adds optional environment variables `OA_LINUX_RUNNER`, `OA_MACOS_RUNNER` and `OA_WINDOWS_RUNNER` which, if set, override the default `-latest` images. The environment variables need to be passed to the reusable workflow directly. E.g.:
```yaml
jobs:
  test:
    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
    with:
      envs: |
        - macos: py310
        - windows: py39-docs
    env:
      OA_WINDOWS_RUNNER: windows-2019
```

xref https://github.com/astropy/extension-helpers/pull/37

Do you think the env var solution is good enough?