### PR TITLE
Add tox workflow input for choosing runner images

### DIFF
--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -11,6 +11,7 @@ jobs:
         - macos: py39-inputs-macos
         - windows: py38-inputs-windows
           toxargs: '-v'
+          runner: windows-2019
 
         - linux: py310-inputs-conda
         - macos: py310-inputs-conda
@@ -25,6 +26,9 @@ jobs:
     uses: ./.github/workflows/tox.yml
     with:
       conda: 'true'
+      runner: |
+        linux: ubuntu-18.04
+        macos: macos-10.15
       envs: |
         # conda present in toxenv
         - linux: py39-inputs-conda
@@ -33,6 +37,7 @@ jobs:
           posargs: not
         # conda not present in toxenv
         - linux: py39-inputs-con_da
+          runner: ubuntu-latest
         - linux: py39-inputs-con_da
           conda: auto
           posargs: not

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -47,6 +47,11 @@ on:
         required: false
         default: false
         type: boolean
+      runner:
+        description: Which runner to use for each platform
+        required: false
+        default: ''
+        type: string
       default_python:
         description: Default version of Python
         required: false
@@ -83,7 +88,7 @@ jobs:
           --posargs "${{ inputs.posargs }}" --toxdeps "${{ inputs.toxdeps }}" \
           --toxargs "${{ inputs.toxargs }}" --pytest "${{ inputs.pytest }}" \
           --coverage "${{ inputs.coverage }}" --conda "${{ inputs.conda }}" \
-          --display "${{ inputs.display }}" \
+          --display "${{ inputs.display }}" --runner "${{ inputs.runner }}" \
           --default-python "${{ inputs.default_python }}"
         shell: sh
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use this template, your repository will need to have a `tox.ini` file.
 
 ```yaml
 jobs:
-  publish:
+  test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:
       posargs: '-n 4'
@@ -149,6 +149,38 @@ For example, `'auto'` would enable conda for tox environments named `py39-conda`
 Whether to setup a headless display.
 This uses the `pyvista/setup-headless-display-action@v1` GitHub Action.
 Default is `false`.
+
+#### runner
+Choose an alternative image for the runner to use on each OS.
+By default, `linux` is `ubuntu-latest`, `macos` is `macos-latest` and `windows` is `windows-latest`.
+None, some or all OSes can be specified, and the global value can be overridden in each environment.
+
+It can be defined globally:
+```yaml
+uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+with:
+  runner: |
+    linux: ubuntu-18.04
+    macos: macos-10.15
+    windows: windows-2019
+```
+```yaml
+uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+with:
+  runner: |
+    macos: macos-10.15
+```
+
+***Note:** `runner` is a **string** and must be specified as a literal block scalar using the `|`. (Without the `|`, it must also be valid YAML.)*
+
+`envs` definition:
+```yaml
+uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+with:
+  envs: |
+    - windows: py39
+      runner: windows-2019
+```
 
 #### default_python
 The version of Python to use if the tox environment name does not start with `py(2|3)[0-9]+`.

--- a/tools/load_build_targets.py
+++ b/tools/load_build_targets.py
@@ -5,9 +5,9 @@ import click
 import yaml
 
 MACHINE_TYPE = {
-    "linux": os.environ.get("OA_LINUX_RUNNER", "ubuntu-latest"),
-    "macos": os.environ.get("OA_MACOS_RUNNER", "macos-latest"),
-    "windows": os.environ.get("OA_WINDOWS_RUNNER", "windows-latest"),
+    "linux": "ubuntu-latest",
+    "macos": "macos-latest",
+    "windows": "windows-latest",
 }
 
 CIBW_BUILD = os.environ.get("CIBW_BUILD", "*")


### PR DESCRIPTION
This reverts the changes made in https://github.com/OpenAstronomy/github-actions-workflows/pull/15 and adds the following new option to the tox workflow only:

#### runner
Choose an alternative image for the runner to use on each OS.
By default, `linux` is `ubuntu-latest`, `macos` is `macos-latest` and `windows` is `windows-latest`.
None, some or all OSes can be specified, and the global value can be overridden in each environment.
It can be defined globally:
```yaml
uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
with:
  runner: |
    linux: ubuntu-18.04
    macos: macos-10.15
    windows: windows-2019
```
```yaml
uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
with:
  runner: |
    macos: macos-10.15
```
***Note:** `runner` is a **string** and must be specified as a literal block scalar using the `|`. (Without the `|`, it must also be valid YAML.)*
`envs` definition:
```yaml
uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
with:
  envs: |
    - windows: py39
      runner: windows-2019
```