### PR TITLE
Simplify pure Python workflow into a single job

### DIFF
--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -59,21 +59,9 @@ jobs:
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
           pure_python_wheel: true
-      - uses: actions/upload-artifact@v2
-        with:
-          path: dist/*
-
-  upload_pypi:
-    name: Upload to PyPI
-    needs: [build]
-    runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')) || inputs.upload_to_pypi
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: artifact
-          path: dist
       - uses: pypa/gh-action-pypi-publish@master
+        name: Upload to PyPI
+        if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')) || inputs.upload_to_pypi
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
As mentioned by @pllim in https://github.com/astropy/pytest-astropy-header/pull/42#issuecomment-1064204463, for the pure Python case we could just have a single job?