### PR TITLE
Add workflow to keep major version tag in sync with minor tags

### DIFF
--- a/.github/workflows/update_tag.yml
+++ b/.github/workflows/update_tag.yml
@@ -1,0 +1,13 @@
+name: Update Major Version Tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  update-majorver:
+    name: Update Major Version Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nowactions/update-majorver@v1


### PR DESCRIPTION
Run `nowactions/update-majorver` on tags.