### PR TITLE
Add `fail-fast` input to `tox.yml` and `publish.yml`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,11 @@ on:
         required: false
         default: ''
         type: string
+      fail-fast:
+        description: Whether to cancel all in-progress jobs if any job fails
+        required: false
+        default: true
+        type: boolean
       submodules:
         description: Whether to checkout submodules
         required: false
@@ -87,6 +92,7 @@ jobs:
     needs: [targets]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{fromJSON(needs.targets.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -57,6 +57,11 @@ on:
         required: false
         default: '3.x'
         type: string
+      fail-fast:
+        description: Whether to cancel all in-progress jobs if any job fails
+        required: false
+        default: false
+        type: boolean
       submodules:
         description: Whether to checkout submodules
         required: false
@@ -98,6 +103,7 @@ jobs:
     needs: [envs]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{fromJSON(needs.envs.outputs.matrix)}}
     steps:
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ Default is `3.x`.
 
 For example, a tox environment `py39-docs` will run on Python 3.9, while a tox environment `build_docs` will refer to the value of `default_python`.
 
+#### fail-fast
+Whether to cancel all in-progress jobs if any job fails.
+Default is `false`.
+
 #### submodules
 Whether to checkout submodules.
 Default is `true`.
@@ -280,6 +284,10 @@ with:
 #### repository_url
 The PyPI repository URL to use.
 Default is the main PyPI repository.
+
+#### fail-fast
+Whether to cancel all in-progress jobs if any job fails.
+Default is `true`.
 
 #### submodules
 Whether to checkout submodules.


### PR DESCRIPTION
This adds a `fail-fast` input to the tox and cibuildwheel publish templates. This is passed directly to [`fail-fast`](https://docs.github.com/en/actions/using-jobs/using-a-build-matrix-for-your-jobs#canceling-remaining-jobs-if-a-matrix-job-fails) in the job stratagy.

#### Default values

For the tox template, I have set it to not fail fast by default because people typically want to see the results for all the tests within a single call to the tox workflow. (And  this is what the Azure template does.) However, this goes against GitHub's default which is `fail-fast: true`.

For the publish template, I have kept the GitHub default option. As this template is more intended for publishing (rather than testing) it would make more sense to give up as soon as possible, and within each job cibuildwheel fails fast anyway.

Does that seem sensible?

Closes #33 