### PR TITLE
Upload to Anaconda.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,16 @@ on:
         required: false
         default: ''
         type: string
+      upload_to_anaconda:
+        description: A condition specifying whether to upload to Anaconda.org
+        required: false
+        default: false
+        type: boolean
+      anaconda_user:
+        description: Anaconda.org user or organisation
+        required: false
+        default: ''
+        type: string
       fail-fast:
         description: Whether to cancel all in-progress jobs if any job fails
         required: false
@@ -53,6 +63,8 @@ on:
         type: boolean
     secrets:
       pypi_token:
+        required: false
+      anaconda_token:
         required: false
 
 jobs:
@@ -143,14 +155,15 @@ jobs:
         with:
           path: dist/*
 
-  upload_pypi:
-    name: Upload to PyPI
+  upload:
+    name: Upload
     needs: [targets, build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: |
       always() &&
       needs.targets.result == 'success' &&
-      needs.targets.outputs.upload_to_pypi == 'true' &&
+      ( needs.targets.outputs.upload_to_pypi == 'true' ||
+        inputs.upload_to_anaconda == 'true' ) &&
       needs.build_wheels.result != 'failure' &&
       needs.build_sdist.result != 'failure'
     steps:
@@ -159,7 +172,17 @@ jobs:
           name: artifact
           path: dist
       - uses: pypa/gh-action-pypi-publish@master
+        name: Upload to PyPI
+        if: ${{ needs.targets.outputs.upload_to_pypi == 'true' }}
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}
           repository_url: ${{ inputs.repository_url }}
+      - name: Upload to Anaconda.org
+        if: ${{ inputs.upload_to_anaconda == 'true' }}
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install git+https://github.com/Anaconda-Server/anaconda-client
+          anaconda --token ${{ secrets.anaconda_token }} upload \
+            --user ${{ inputs.anaconda_user }} \
+            dist/*

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -28,6 +28,16 @@ on:
         required: false
         default: ''
         type: string
+      upload_to_anaconda:
+        description: A condition specifying whether to upload to Anaconda.org
+        required: false
+        default: false
+        type: boolean
+      anaconda_user:
+        description: Anaconda.org user or organisation
+        required: false
+        default: ''
+        type: string
       submodules:
         description: Whether to checkout submodules
         required: false
@@ -35,6 +45,8 @@ on:
         type: boolean
     secrets:
       pypi_token:
+        required: false
+      anaconda_token:
         required: false
 
 jobs:
@@ -77,3 +89,11 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           repository_url: ${{ inputs.repository_url }}
+      - name: Upload to Anaconda.org
+        if: ${{ inputs.upload_to_anaconda == 'true' }}
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install git+https://github.com/Anaconda-Server/anaconda-client
+          anaconda --token ${{ secrets.anaconda_token }} upload \
+            --user ${{ inputs.anaconda_user }} \
+            dist/*

--- a/README.md
+++ b/README.md
@@ -285,6 +285,16 @@ with:
 The PyPI repository URL to use.
 Default is the main PyPI repository.
 
+#### upload_to_anaconda
+Whether to upload to Anaconda.org after successful builds.
+The default is to not upload.
+A boolean can be passed as `true` (always upload) or `false` (never upload)
+either explicitly or as a boolean expression (`${{ <expression> }}`).
+
+#### anaconda_user
+Anaconda.org user or organisation.
+Required if `upload_to_anaconda` is true.
+
 #### fail-fast
 Whether to cancel all in-progress jobs if any job fails.
 Default is `true`.
@@ -297,6 +307,9 @@ Default is `true`.
 
 #### pypi_token
 The authentication token to access the PyPI repository.
+
+#### anaconda_token
+The authentication token to access the Anaconda.org repository.
 
 ## Build and publish a pure Python package
 
@@ -348,6 +361,16 @@ with:
 The PyPI repository URL to use.
 Default is the main PyPI repository.
 
+#### upload_to_anaconda
+Whether to upload to Anaconda.org after successful builds.
+The default is to not upload.
+A boolean can be passed as `true` (always upload) or `false` (never upload)
+either explicitly or as a boolean expression (`${{ <expression> }}`).
+
+#### anaconda_user
+Anaconda.org user or organisation.
+Required if `upload_to_anaconda` is true.
+
 #### submodules
 Whether to checkout submodules.
 Default is `true`.
@@ -356,3 +379,6 @@ Default is `true`.
 
 #### pypi_token
 The authentication token to access the PyPI repository.
+
+#### anaconda_token
+The authentication token to access the Anaconda.org repository.


### PR DESCRIPTION
This adds support for uploading to Anaconda.org in both of the publishing workflows. Matplotlib are now doing something similar for uploading nightly builds to Anaconda.org: https://github.com/matplotlib/matplotlib/blob/main/.github/workflows/nightlies.yml 
Although they are uploading the latest artifact instead of building new wheels especially for uploading.

Closes #8 