### PR TITLE
Set publish workflow to not fail-fast by default

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ on:
       fail-fast:
         description: Whether to cancel all in-progress jobs if any job fails
         required: false
-        default: true
+        default: false
         type: boolean
       submodules:
         description: Whether to checkout submodules

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Required if `upload_to_anaconda` is true.
 
 #### fail-fast
 Whether to cancel all in-progress jobs if any job fails.
-Default is `true`.
+Default is `false`.
 
 #### submodules
 Whether to checkout submodules.


### PR DESCRIPTION
See https://github.com/OpenAstronomy/github-actions-workflows/pull/35#issuecomment-1088945407