### PR TITLE
Add `pass_filenames: false` to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,4 @@ repos:
         language: system
         entry: python update_scripts_in_yml.py
         always_run: true
+        pass_filenames: false


### PR DESCRIPTION
Previously, pre-commit was running multiple times in batches including all the files in the repo (6 batches with 4 files each). This was resulting in simultaneous reads of the same workflow file, which seemed to cause an empty file to be read randomly.

This updates the config to not pass the filenames and therefore only run once. I have tested this locally and the random failures no longer occur. (Maybe it'll also fix the issue with the auto-fix command not committing the fix.)