### PR TITLE
Pure/non-pure package based on current workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,6 @@
 requires = ["setuptools>=43.0.0",
             "wheel"]
 build-backend = 'setuptools.build_meta'
+
+[tool.cibuildwheel.linux]
+environment-pass = ["GITHUB_WORKFLOW"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 import os
 
-from setuptools import Extension, setup
+if os.getenv("GITHUB_WORKFLOW") == ".github/workflows/test_publish.yml":
+    from setuptools import Extension, setup
 
-setup(ext_modules=[Extension('test_package.simple',
-                             [os.path.join('test_package', 'simple.c')])])
+    setup(ext_modules=[Extension('test_package.simple',
+                                 [os.path.join('test_package', 'simple.c')])])
+else:
+    from setuptools import setup
+
+    setup()

--- a/test_package/__init__.py
+++ b/test_package/__init__.py
@@ -1,3 +1,6 @@
-from . import simple
+import os
 
-__all__ = ["simple"]
+if os.getenv("GITHUB_WORKFLOW") == ".github/workflows/test_publish.yml":
+    from . import simple
+
+    __all__ = ["simple"]


### PR DESCRIPTION
If the workflow named ".github/workflows/test_publish.yml" is running, the package will be non-pure. Otherwise, it will be pure Python.

Fixes #41 