### PR TITLE
Fix condition for uploading to Anaconda.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,7 +163,7 @@ jobs:
       always() &&
       needs.targets.result == 'success' &&
       ( needs.targets.outputs.upload_to_pypi == 'true' ||
-        inputs.upload_to_anaconda == 'true' ) &&
+        inputs.upload_to_anaconda ) &&
       needs.build_wheels.result != 'failure' &&
       needs.build_sdist.result != 'failure'
     steps:
@@ -179,7 +179,7 @@ jobs:
           password: ${{ secrets.pypi_token }}
           repository_url: ${{ inputs.repository_url }}
       - name: Upload to Anaconda.org
-        if: ${{ inputs.upload_to_anaconda == 'true' }}
+        if: ${{ inputs.upload_to_anaconda }}
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install git+https://github.com/Anaconda-Server/anaconda-client

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -90,7 +90,7 @@ jobs:
           password: ${{ secrets.pypi_token }}
           repository_url: ${{ inputs.repository_url }}
       - name: Upload to Anaconda.org
-        if: ${{ inputs.upload_to_anaconda == 'true' }}
+        if: ${{ inputs.upload_to_anaconda }}
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install git+https://github.com/Anaconda-Server/anaconda-client


### PR DESCRIPTION
Input is bool so no need to compare to anything. Previously, "If the types do not match, GitHub coerces the type to a number." therefore `inputs.upload_to_anaconda` which is bool `true` gets converted to `1`, and `'true'` which is a non-empty non-number string gets converted to `nan`. So it's `false` as `1` is not equal to `nan`.