### PR TITLE
Don't hard-code minor/bugfix version for cibuildwheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           platforms: all
       - name: Run cibuildwheel
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.5.0
         with:
           output-dir: dist
         env:


### PR DESCRIPTION
It would be good to allow the latest version to be used - 2.5.0 includes support for the limited API