### PR TITLE
Add option to set environment variables when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: ''
         type: string
+      env:
+        description: A map of environment variables to be available when building and testing
+        required: false
+        default: ''
+        type: string
       libraries:
         description: Packages needed to build the source distribution for testing (installed using apt)
         required: false
@@ -138,6 +143,19 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all
+      - uses: actions/setup-python@v4
+        if: ${{ inputs.env != '' }}
+        with:
+          python-version: '3.9'
+      - id: set-env
+        if: ${{ inputs.env != '' }}
+        run: |
+          python -m pip install PyYAML
+          echo $SET_ENV_SCRIPT | base64 --decode > set_env.py
+          python set_env.py "${{ inputs.env }}"
+        shell: sh
+        env:
+          SET_ENV_SCRIPT: aW1wb3J0IGpzb24KaW1wb3J0IG9zCmltcG9ydCBzeXMKCmltcG9ydCB5YW1sCgpHSVRIVUJfRU5WID0gb3MuZ2V0ZW52KCJHSVRIVUJfRU5WIikKaWYgR0lUSFVCX0VOViBpcyBOb25lOgogICAgcmFpc2UgVmFsdWVFcnJvcigiR0lUSFVCX0VOViBub3Qgc2V0LiBNdXN0IGJlIHJ1biBpbnNpZGUgR2l0SHViIEFjdGlvbnMuIikKCkRFTElNSVRFUiA9ICJFT0YiCgoKZGVmIHNldF9lbnYoZW52KToKCiAgICBlbnYgPSB5YW1sLmxvYWQoZW52LCBMb2FkZXI9eWFtbC5CYXNlTG9hZGVyKQogICAgcHJpbnQoanNvbi5kdW1wcyhlbnYsIGluZGVudD0yKSkKCiAgICBpZiBub3QgaXNpbnN0YW5jZShlbnYsIGRpY3QpOgogICAgICAgIHRpdGxlID0gImBlbnZgIG11c3QgYmUgbWFwcGluZyIKICAgICAgICBtZXNzYWdlID0gZiJgZW52YCBtdXN0IGJlIG1hcHBpbmcgb2YgZW52IHZhcmlhYmxlcyB0byB2YWx1ZXMsIGdvdCB0eXBlIHt0eXBlKGVudil9IgogICAgICAgIHByaW50KGYiOjplcnJvciB0aXRsZT17dGl0bGV9Ojp7bWVzc2FnZX0iKQogICAgICAgIGV4aXQoMSkKCiAgICBmb3IgaywgdiBpbiBlbnYuaXRlbXMoKToKCiAgICAgICAgaWYgbm90IGlzaW5zdGFuY2Uodiwgc3RyKToKICAgICAgICAgICAgdGl0bGUgPSAiYGVudmAgdmFsdWVzIG11c3QgYmUgc3RyaW5ncyIKICAgICAgICAgICAgbWVzc2FnZSA9IGYiYGVudmAgdmFsdWVzIG11c3QgYmUgc3RyaW5ncywgYnV0IHZhbHVlIG9mIHtrfSBoYXMgdHlwZSB7dHlwZSh2KX0iCiAgICAgICAgICAgIHByaW50KGYiOjplcnJvciB0aXRsZT17dGl0bGV9Ojp7bWVzc2FnZX0iKQogICAgICAgICAgICBleGl0KDEpCgogICAgICAgIHYgPSB2LnNwbGl0KCJcbiIpCgogICAgICAgIHdpdGggb3BlbihHSVRIVUJfRU5WLCAiYSIpIGFzIGY6CiAgICAgICAgICAgIGlmIGxlbih2KSA9PSAxOgogICAgICAgICAgICAgICAgZi53cml0ZShmIntrfT17dlswXX1cbiIpCiAgICAgICAgICAgIGVsc2U6CiAgICAgICAgICAgICAgICBmb3IgbGluZSBpbiB2OgogICAgICAgICAgICAgICAgICAgIGFzc2VydCBsaW5lLnN0cmlwKCkgIT0gREVMSU1JVEVSCiAgICAgICAgICAgICAgICBmLndyaXRlKGYie2t9PDx7REVMSU1JVEVSfVxuIikKICAgICAgICAgICAgICAgIGZvciBsaW5lIGluIHY6CiAgICAgICAgICAgICAgICAgICAgZi53cml0ZShmIntsaW5lfVxuIikKICAgICAgICAgICAgICAgIGYud3JpdGUoZiJ7REVMSU1JVEVSfVxuIikKCiAgICAgICAgcHJpbnQoZiJ7a30gd3JpdHRlbiB0byBHSVRIVUJfRU5WIikKCgppZiBfX25hbWVfXyA9PSAiX19tYWluX18iOgogICAgc2V0X2VudihzeXMuYXJndlsxXSkK
       - name: Run cibuildwheel
         uses: pypa/cibuildwheel@v2.12.0
         with:
@@ -157,6 +175,19 @@ jobs:
     runs-on: ${{ inputs.sdist-runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
+      - uses: actions/setup-python@v4
+        if: ${{ inputs.env != '' }}
+        with:
+          python-version: '3.9'
+      - id: set-env
+        if: ${{ inputs.env != '' }}
+        run: |
+          python -m pip install PyYAML
+          echo $SET_ENV_SCRIPT | base64 --decode > set_env.py
+          python set_env.py "${{ inputs.env }}"
+        shell: sh
+        env:
+          SET_ENV_SCRIPT: aW1wb3J0IGpzb24KaW1wb3J0IG9zCmltcG9ydCBzeXMKCmltcG9ydCB5YW1sCgpHSVRIVUJfRU5WID0gb3MuZ2V0ZW52KCJHSVRIVUJfRU5WIikKaWYgR0lUSFVCX0VOViBpcyBOb25lOgogICAgcmFpc2UgVmFsdWVFcnJvcigiR0lUSFVCX0VOViBub3Qgc2V0LiBNdXN0IGJlIHJ1biBpbnNpZGUgR2l0SHViIEFjdGlvbnMuIikKCkRFTElNSVRFUiA9ICJFT0YiCgoKZGVmIHNldF9lbnYoZW52KToKCiAgICBlbnYgPSB5YW1sLmxvYWQoZW52LCBMb2FkZXI9eWFtbC5CYXNlTG9hZGVyKQogICAgcHJpbnQoanNvbi5kdW1wcyhlbnYsIGluZGVudD0yKSkKCiAgICBpZiBub3QgaXNpbnN0YW5jZShlbnYsIGRpY3QpOgogICAgICAgIHRpdGxlID0gImBlbnZgIG11c3QgYmUgbWFwcGluZyIKICAgICAgICBtZXNzYWdlID0gZiJgZW52YCBtdXN0IGJlIG1hcHBpbmcgb2YgZW52IHZhcmlhYmxlcyB0byB2YWx1ZXMsIGdvdCB0eXBlIHt0eXBlKGVudil9IgogICAgICAgIHByaW50KGYiOjplcnJvciB0aXRsZT17dGl0bGV9Ojp7bWVzc2FnZX0iKQogICAgICAgIGV4aXQoMSkKCiAgICBmb3IgaywgdiBpbiBlbnYuaXRlbXMoKToKCiAgICAgICAgaWYgbm90IGlzaW5zdGFuY2Uodiwgc3RyKToKICAgICAgICAgICAgdGl0bGUgPSAiYGVudmAgdmFsdWVzIG11c3QgYmUgc3RyaW5ncyIKICAgICAgICAgICAgbWVzc2FnZSA9IGYiYGVudmAgdmFsdWVzIG11c3QgYmUgc3RyaW5ncywgYnV0IHZhbHVlIG9mIHtrfSBoYXMgdHlwZSB7dHlwZSh2KX0iCiAgICAgICAgICAgIHByaW50KGYiOjplcnJvciB0aXRsZT17dGl0bGV9Ojp7bWVzc2FnZX0iKQogICAgICAgICAgICBleGl0KDEpCgogICAgICAgIHYgPSB2LnNwbGl0KCJcbiIpCgogICAgICAgIHdpdGggb3BlbihHSVRIVUJfRU5WLCAiYSIpIGFzIGY6CiAgICAgICAgICAgIGlmIGxlbih2KSA9PSAxOgogICAgICAgICAgICAgICAgZi53cml0ZShmIntrfT17dlswXX1cbiIpCiAgICAgICAgICAgIGVsc2U6CiAgICAgICAgICAgICAgICBmb3IgbGluZSBpbiB2OgogICAgICAgICAgICAgICAgICAgIGFzc2VydCBsaW5lLnN0cmlwKCkgIT0gREVMSU1JVEVSCiAgICAgICAgICAgICAgICBmLndyaXRlKGYie2t9PDx7REVMSU1JVEVSfVxuIikKICAgICAgICAgICAgICAgIGZvciBsaW5lIGluIHY6CiAgICAgICAgICAgICAgICAgICAgZi53cml0ZShmIntsaW5lfVxuIikKICAgICAgICAgICAgICAgIGYud3JpdGUoZiJ7REVMSU1JVEVSfVxuIikKCiAgICAgICAgcHJpbnQoZiJ7a30gd3JpdHRlbiB0byBHSVRIVUJfRU5WIikKCgppZiBfX25hbWVfXyA9PSAiX19tYWluX18iOgogICAgc2V0X2VudihzeXMuYXJndlsxXSkK
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: ''
         type: string
+      env:
+        description: A map of environment variables to be available when building and testing
+        required: false
+        default: ''
+        type: string
       libraries:
         description: Packages needed to build the source distribution for testing (installed using apt)
         required: false
@@ -81,6 +86,19 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
+      - uses: actions/setup-python@v4
+        if: ${{ inputs.env != '' }}
+        with:
+          python-version: '3.9'
+      - id: set-env
+        if: ${{ inputs.env != '' }}
+        run: |
+          python -m pip install PyYAML
+          echo $SET_ENV_SCRIPT | base64 --decode > set_env.py
+          python set_env.py "${{ inputs.env }}"
+        shell: sh
+        env:
+          SET_ENV_SCRIPT: aW1wb3J0IGpzb24KaW1wb3J0IG9zCmltcG9ydCBzeXMKCmltcG9ydCB5YW1sCgpHSVRIVUJfRU5WID0gb3MuZ2V0ZW52KCJHSVRIVUJfRU5WIikKaWYgR0lUSFVCX0VOViBpcyBOb25lOgogICAgcmFpc2UgVmFsdWVFcnJvcigiR0lUSFVCX0VOViBub3Qgc2V0LiBNdXN0IGJlIHJ1biBpbnNpZGUgR2l0SHViIEFjdGlvbnMuIikKCkRFTElNSVRFUiA9ICJFT0YiCgoKZGVmIHNldF9lbnYoZW52KToKCiAgICBlbnYgPSB5YW1sLmxvYWQoZW52LCBMb2FkZXI9eWFtbC5CYXNlTG9hZGVyKQogICAgcHJpbnQoanNvbi5kdW1wcyhlbnYsIGluZGVudD0yKSkKCiAgICBpZiBub3QgaXNpbnN0YW5jZShlbnYsIGRpY3QpOgogICAgICAgIHRpdGxlID0gImBlbnZgIG11c3QgYmUgbWFwcGluZyIKICAgICAgICBtZXNzYWdlID0gZiJgZW52YCBtdXN0IGJlIG1hcHBpbmcgb2YgZW52IHZhcmlhYmxlcyB0byB2YWx1ZXMsIGdvdCB0eXBlIHt0eXBlKGVudil9IgogICAgICAgIHByaW50KGYiOjplcnJvciB0aXRsZT17dGl0bGV9Ojp7bWVzc2FnZX0iKQogICAgICAgIGV4aXQoMSkKCiAgICBmb3IgaywgdiBpbiBlbnYuaXRlbXMoKToKCiAgICAgICAgaWYgbm90IGlzaW5zdGFuY2Uodiwgc3RyKToKICAgICAgICAgICAgdGl0bGUgPSAiYGVudmAgdmFsdWVzIG11c3QgYmUgc3RyaW5ncyIKICAgICAgICAgICAgbWVzc2FnZSA9IGYiYGVudmAgdmFsdWVzIG11c3QgYmUgc3RyaW5ncywgYnV0IHZhbHVlIG9mIHtrfSBoYXMgdHlwZSB7dHlwZSh2KX0iCiAgICAgICAgICAgIHByaW50KGYiOjplcnJvciB0aXRsZT17dGl0bGV9Ojp7bWVzc2FnZX0iKQogICAgICAgICAgICBleGl0KDEpCgogICAgICAgIHYgPSB2LnNwbGl0KCJcbiIpCgogICAgICAgIHdpdGggb3BlbihHSVRIVUJfRU5WLCAiYSIpIGFzIGY6CiAgICAgICAgICAgIGlmIGxlbih2KSA9PSAxOgogICAgICAgICAgICAgICAgZi53cml0ZShmIntrfT17dlswXX1cbiIpCiAgICAgICAgICAgIGVsc2U6CiAgICAgICAgICAgICAgICBmb3IgbGluZSBpbiB2OgogICAgICAgICAgICAgICAgICAgIGFzc2VydCBsaW5lLnN0cmlwKCkgIT0gREVMSU1JVEVSCiAgICAgICAgICAgICAgICBmLndyaXRlKGYie2t9PDx7REVMSU1JVEVSfVxuIikKICAgICAgICAgICAgICAgIGZvciBsaW5lIGluIHY6CiAgICAgICAgICAgICAgICAgICAgZi53cml0ZShmIntsaW5lfVxuIikKICAgICAgICAgICAgICAgIGYud3JpdGUoZiJ7REVMSU1JVEVSfVxuIikKCiAgICAgICAgcHJpbnQoZiJ7a30gd3JpdHRlbiB0byBHSVRIVUJfRU5WIikKCgppZiBfX25hbWVfXyA9PSAiX19tYWluX18iOgogICAgc2V0X2VudihzeXMuYXJndlsxXSkK
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/test_publish_pure_python.yml
+++ b/.github/workflows/test_publish_pure_python.yml
@@ -9,3 +9,10 @@ jobs:
       test_extras: test
       test_command: pytest --pyargs test_package
       timeout-minutes: 5
+
+  setenv:
+    uses: ./.github/workflows/publish_pure_python.yml
+    with:
+      test_command: python -c "import os; assert os.getenv('CUSTOM_VAR') == 'custom value'"
+      env: |
+        CUSTOM_VAR: custom value

--- a/README.md
+++ b/README.md
@@ -349,6 +349,24 @@ The command to run to test the package.
 Will be run in a temporary directory.
 Default is no testing.
 
+#### env
+A map of environment variables to be available when building and testing.
+Default is none.
+
+Due to [GitHub Actions limitations](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
+this is the only way to pass environment variables from your workflow file into the publishing job.
+
+```yaml
+uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+with:
+  env: |
+    VAR1: test
+    VAR2: |
+      first line
+      seconds line
+    VAR3: testing
+```
+
 #### libraries
 Packages needed to build the source distribution for testing. Must be a string of space-separated apt packages.
 Default is install nothing extra.
@@ -364,7 +382,7 @@ For example, `'refs/tags/v'` (default) will upload tags that begin with `v`,
 and `'refs/tags/'` will upload on all pushed tags.
 
 ```yaml
-uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
+uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
 with:
   upload_to_pypi: refs/tags/
 ```
@@ -440,6 +458,24 @@ Default is none.
 The command to run to test the package.
 Will be run in a temporary directory.
 Default is no testing.
+
+#### env
+A map of environment variables to be available when building and testing.
+Default is none.
+
+Due to [GitHub Actions limitations](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
+this is the only way to pass environment variables from your workflow file into the publishing job.
+
+```yaml
+uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
+with:
+  env: |
+    VAR1: test
+    VAR2: |
+      first line
+      seconds line
+    VAR3: testing
+```
 
 #### libraries
 Packages needed to build the source distribution for testing. Must be a string of space-separated apt packages.

--- a/tools/set_env.py
+++ b/tools/set_env.py
@@ -1,0 +1,50 @@
+import json
+import os
+import sys
+
+import yaml
+
+GITHUB_ENV = os.getenv("GITHUB_ENV")
+if GITHUB_ENV is None:
+    raise ValueError("GITHUB_ENV not set. Must be run inside GitHub Actions.")
+
+DELIMITER = "EOF"
+
+
+def set_env(env):
+
+    env = yaml.load(env, Loader=yaml.BaseLoader)
+    print(json.dumps(env, indent=2))
+
+    if not isinstance(env, dict):
+        title = "`env` must be mapping"
+        message = f"`env` must be mapping of env variables to values, got type {type(env)}"
+        print(f"::error title={title}::{message}")
+        exit(1)
+
+    for k, v in env.items():
+
+        if not isinstance(v, str):
+            title = "`env` values must be strings"
+            message = f"`env` values must be strings, but value of {k} has type {type(v)}"
+            print(f"::error title={title}::{message}")
+            exit(1)
+
+        v = v.split("\n")
+
+        with open(GITHUB_ENV, "a") as f:
+            if len(v) == 1:
+                f.write(f"{k}={v[0]}\n")
+            else:
+                for line in v:
+                    assert line.strip() != DELIMITER
+                f.write(f"{k}<<{DELIMITER}\n")
+                for line in v:
+                    f.write(f"{line}\n")
+                f.write(f"{DELIMITER}\n")
+
+        print(f"{k} written to GITHUB_ENV")
+
+
+if __name__ == "__main__":
+    set_env(sys.argv[1])

--- a/update_scripts_in_yml.py
+++ b/update_scripts_in_yml.py
@@ -12,12 +12,13 @@ def base64_encode_into(script, yml_file, env_var):
 
     tox_yml_lines = tox_yml.splitlines()
 
+    updated = False
     for i in range(len(tox_yml_lines)):
         if tox_yml_lines[i].strip().startswith(env_var + ':'):
             pos = tox_yml_lines[i].index(':')
             tox_yml_lines[i] = tox_yml_lines[i][:pos+1] + ' ' + tox_matrix_base64
-            break
-    else:
+            updated = True
+    if not updated:
         raise ValueError(f'No line containing {env_var} found')
 
     tox_yml_new = '\n'.join(tox_yml_lines) + '\n'
@@ -28,3 +29,5 @@ def base64_encode_into(script, yml_file, env_var):
 
 base64_encode_into('tox_matrix.py', 'tox.yml', 'TOX_MATRIX_SCRIPT')
 base64_encode_into('load_build_targets.py', 'publish.yml', 'LOAD_BUILD_TARGETS_SCRIPT')
+base64_encode_into('set_env.py', 'publish.yml', 'SET_ENV_SCRIPT')
+base64_encode_into('set_env.py', 'publish_pure_python.yml', 'SET_ENV_SCRIPT')


### PR DESCRIPTION
Not sure about this. I think it would be neater as an independent JavaScript action. I couldn't find any existing actions that would accept a string as input.

Alternatively, if people give the env variables in a format which can be written to the `GITHUB_ENV` file directly, we wouldn't need to use Python. That is, give:
```yaml
env: |
  VAR1=test
  VAR2<<EOF
  first line
  seconds line
  EOF
  VAR3=testing
```
instead of 
```yaml
env: |
  VAR1: test
  VAR2: |
    first line
    seconds line
  VAR3: testing
```