### PR TITLE
Use conda to install `anaconda-client`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -183,11 +183,13 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           repository_url: ${{ inputs.repository_url }}
+      - uses: conda-incubator/setup-miniconda@v2
+        if: ${{ inputs.upload_to_anaconda }}
       - name: Upload to Anaconda.org
         if: ${{ inputs.upload_to_anaconda }}
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install git+https://github.com/Anaconda-Server/anaconda-client
+          conda install --yes anaconda-client
           anaconda --token ${{ secrets.anaconda_token }} upload \
             --user ${{ inputs.anaconda_user }} \
             dist/*
+        shell: bash -l {0}

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -94,11 +94,13 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           repository_url: ${{ inputs.repository_url }}
+      - uses: conda-incubator/setup-miniconda@v2
+        if: ${{ inputs.upload_to_anaconda }}
       - name: Upload to Anaconda.org
         if: ${{ inputs.upload_to_anaconda }}
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install git+https://github.com/Anaconda-Server/anaconda-client
+          conda install --yes anaconda-client
           anaconda --token ${{ secrets.anaconda_token }} upload \
             --user ${{ inputs.anaconda_user }} \
             dist/*
+        shell: bash -l {0}


### PR DESCRIPTION
Fixes a bug with uploading to Anaconda.org seen at https://github.com/astropy/astropy/issues/13348. `anaconda-client` is intended to be installed by conda (not pip, as some of its dependencies are not on PyPI). This PR switches the install method for this package from pip to conda.

- [x] Delete TMP commit before merging

cc @pllim 