### PR TITLE
Use publish-wheels-anaconda

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,7 +201,7 @@ jobs:
           password: ${{ secrets.pypi_token }}
           repository_url: ${{ inputs.repository_url }}
       - uses: OpenAstronomy/publish-wheels-anaconda@main
-        if: ${{ needs.targets.outputs.upload_to_anaconda == 'true' }}
+        if: ${{ inputs.upload_to_anaconda }}
         with:
           anaconda_user: ${{ inputs.anaconda_user }}
           anaconda_package: ${{ inputs.anaconda_package }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,16 @@ on:
         required: false
         default: ''
         type: string
+      anaconda_package:
+        description: Anaconda.org package name
+        required: false
+        default: ''
+        type: string
+      anaconda_keep_n_latest:
+        description: If specified, only this number of the most recent versions are kept
+        required: false
+        default: -1
+        type: number
       fail-fast:
         description: Whether to cancel all in-progress jobs if any job fails
         required: false
@@ -190,13 +200,10 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           repository_url: ${{ inputs.repository_url }}
-      - uses: conda-incubator/setup-miniconda@v2
-        if: ${{ inputs.upload_to_anaconda }}
-      - name: Upload to Anaconda.org
-        if: ${{ inputs.upload_to_anaconda }}
-        run: |
-          conda install --yes anaconda-client
-          anaconda --token ${{ secrets.anaconda_token }} upload \
-            --user ${{ inputs.anaconda_user }} \
-            dist/*
-        shell: bash -l {0}
+      - uses: OpenAstronomy/publish-wheels-anaconda@main
+        if: ${{ needs.targets.outputs.upload_to_anaconda == 'true' }}
+        with:
+          anaconda_user: ${{ inputs.anaconda_user }}
+          anaconda_package: ${{ inputs.anaconda_package }}
+          anaconda_token: ${{ secrets.anaconda_token }}
+          keep_n_latest: ${{ inputs.anaconda_keep_n_latest }}

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -111,7 +111,7 @@ jobs:
           password: ${{ secrets.pypi_token }}
           repository_url: ${{ inputs.repository_url }}
       - uses: OpenAstronomy/publish-wheels-anaconda@main
-        if: ${{ needs.targets.outputs.upload_to_anaconda == 'true' }}
+        if: ${{ inputs.upload_to_anaconda }}
         with:
           anaconda_user: ${{ inputs.anaconda_user }}
           anaconda_package: ${{ inputs.anaconda_package }}

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -43,6 +43,16 @@ on:
         required: false
         default: ''
         type: string
+      anaconda_package:
+        description: Anaconda.org package name
+        required: false
+        default: ''
+        type: string
+      anaconda_keep_n_latest:
+        description: If specified, only this number of the most recent versions are kept
+        required: false
+        default: -1
+        type: number
       timeout-minutes:
         description: The maximum number of minutes to let the workflow run before GitHub automatically cancels it
         required: false
@@ -100,13 +110,10 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           repository_url: ${{ inputs.repository_url }}
-      - uses: conda-incubator/setup-miniconda@v2
-        if: ${{ inputs.upload_to_anaconda }}
-      - name: Upload to Anaconda.org
-        if: ${{ inputs.upload_to_anaconda }}
-        run: |
-          conda install --yes anaconda-client
-          anaconda --token ${{ secrets.anaconda_token }} upload \
-            --user ${{ inputs.anaconda_user }} \
-            dist/*
-        shell: bash -l {0}
+      - uses: OpenAstronomy/publish-wheels-anaconda@main
+        if: ${{ needs.targets.outputs.upload_to_anaconda == 'true' }}
+        with:
+          anaconda_user: ${{ inputs.anaconda_user }}
+          anaconda_package: ${{ inputs.anaconda_package }}
+          anaconda_token: ${{ secrets.anaconda_token }}
+          keep_n_latest: ${{ inputs.anaconda_keep_n_latest }}

--- a/README.md
+++ b/README.md
@@ -383,6 +383,13 @@ either explicitly or as a boolean expression (`${{ <expression> }}`).
 Anaconda.org user or organisation.
 Required if `upload_to_anaconda` is true.
 
+#### anaconda_package
+Anaconda.org package.
+Required if `upload_to_anaconda` is true.
+
+#### anaconda_keep_n_latest
+If specified, keep only this number of versions (starting from the most recent) and remove older versions. This can be useful to prevent a build-up of too many files when uploading developer versions.
+
 #### fail-fast
 Whether to cancel all in-progress jobs if any job fails.
 Default is `false`.
@@ -467,6 +474,13 @@ either explicitly or as a boolean expression (`${{ <expression> }}`).
 #### anaconda_user
 Anaconda.org user or organisation.
 Required if `upload_to_anaconda` is true.
+
+#### anaconda_package
+Anaconda.org package.
+Required if `upload_to_anaconda` is true.
+
+#### anaconda_keep_n_latest
+If specified, keep only this number of versions (starting from the most recent) and remove older versions. This can be useful to prevent a build-up of too many files when uploading developer versions.
 
 #### timeout-minutes
 The maximum number of minutes to let the workflow run before GitHub automatically cancels it.


### PR DESCRIPTION
This switches to the new Action I wrote to upload the files to anaconda and optionally remove old versions (to prevent build-up of too many developer versions).

A few questions/open issues before this can be merged:

* Are we happy with the name of the action or can we think of a better name? (I'm not attached to the current one)
* Is there a way to avoid having to define anaconda_package?
* Currently the action hard-codes dist/* but we could potentially allow that to be customized
* Would it make sense to test the anaconda upload here somehow? In the action we do test uploading to the anaconda.org for real using a test user so maybe we could do the same here?

I don't have much time to work on this in the near future so if someone wants to take the charge on this please feel free to!
