### PR TITLE
remove warning by updating action versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
       matrix: ${{ steps.set-outputs.outputs.matrix }}
       upload_to_pypi: ${{ steps.set-upload.outputs.upload_to_pypi }}
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
       - run: python -m pip install PyYAML click
@@ -112,18 +112,18 @@ jobs:
       fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{fromJSON(needs.targets.outputs.matrix)}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           lfs: true
           submodules: ${{ inputs.submodules }}
       - name: Set up QEMU
         if: ${{ matrix.CIBW_ARCHS == 'aarch64' }}
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
       - name: Run cibuildwheel
-        uses: pypa/cibuildwheel@v2.5.0
+        uses: pypa/cibuildwheel@v2
         with:
           output-dir: dist
         env:
@@ -131,7 +131,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.CIBW_ARCHS }}
           CIBW_TEST_EXTRAS: ${{ inputs.test_extras }}
           CIBW_TEST_COMMAND: ${{ inputs.test_command }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*
 
@@ -140,7 +140,7 @@ jobs:
     if: ${{ inputs.sdist }}
     runs-on: ${{ inputs.sdist-runs-on }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           lfs: true
@@ -156,7 +156,7 @@ jobs:
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
           pure_python_wheel: false
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*
 
@@ -172,7 +172,7 @@ jobs:
       needs.build_wheels.result != 'failure' &&
       needs.build_sdist.result != 'failure'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,7 @@ jobs:
         with:
           platforms: all
       - name: Run cibuildwheel
-        uses: pypa/cibuildwheel@v2
+        uses: pypa/cibuildwheel@v2.8.1
         with:
           output-dir: dist
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,7 +176,7 @@ jobs:
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         name: Upload to PyPI
         if: ${{ needs.targets.outputs.upload_to_pypi == 'true' }}
         with:

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -60,7 +60,7 @@ jobs:
     name: Build source and wheel distribution
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           lfs: true

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           UPLOAD_TO_PYPI: ${{ inputs.upload_to_pypi }}
           UPLOAD_TAG: ${{ startsWith(inputs.upload_to_pypi, 'refs/tags/') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'release' || github.event_name == 'create') && startsWith(github.ref, inputs.upload_to_pypi) }}
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         name: Upload to PyPI
         if: ${{ steps.set-upload.outputs.upload_to_pypi == 'true' }}
         with:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -95,7 +95,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-outputs.outputs.matrix }}
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
       - run: python -m pip install PyYAML click
@@ -123,7 +123,7 @@ jobs:
       matrix: ${{fromJSON(needs.envs.outputs.matrix)}}
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           lfs: true
@@ -147,7 +147,7 @@ jobs:
 
       - name: Setup Python ${{ matrix.python_version }}
         if: ${{ matrix.conda != 'true' }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -172,6 +172,6 @@ jobs:
 
       - name: Upload to Codecov
         if: ${{ contains(matrix.coverage, 'codecov') && matrix.pytest == 'true' }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ $RECYCLE.BIN/
 
 ### Pycharm
 .idea
+.history


### PR DESCRIPTION
You are using "pypa/gh-action-pypi-publish@master". 
The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes. 
Please, make sure to use a supported version. If you want to pin to v1 major version, use "pypa/gh-action-pypi-publish@release/v1". 
If you feel adventurous, you may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. 
A more general recommendation is to pin to exact tags or commit shas.