### PR TITLE
Allow passing Python version in pure python publish workflow

### DIFF
--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
+          python-version: ${{ inputs.python-version }}
           pure_python_wheel: true
       - id: set-upload
         run: |

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -63,6 +63,11 @@ on:
         required: false
         default: true
         type: boolean
+      python-version:
+        description: The Python version to use for building and testing
+        required: false
+        default: '3.x'
+        type: string
     secrets:
       pypi_token:
         required: false

--- a/README.md
+++ b/README.md
@@ -445,6 +445,9 @@ Default is no testing.
 Packages needed to build the source distribution for testing. Must be a string of space-separated apt packages.
 Default is install nothing extra.
 
+#### python-version
+The version of Python used to test and build the package. By default, this is `3.x`.
+
 #### upload_to_pypi
 Whether to upload to PyPI after successful builds.
 The default is to upload to PyPI when tags that start with `v` are pushed.


### PR DESCRIPTION
This allows passing in a Python version when using the pure Python publish workflow. I think this should propagate to the build-python-dist workflow.