### PR TITLE
Fix libraries tests

### DIFF
--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -70,12 +70,12 @@ jobs:
         apt:
           - rolldice
         brew:
-          - graphviz
+          - openjpeg
       envs: |
         - linux: libraries
           posargs: 'rolldice -v'
         - macos: libraries
-          posargs: 'dot -V'
+          posargs: 'opj_compress -h'
         - linux: libraries
           posargs: 'bcal -h'
           libraries:

--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -75,7 +75,7 @@ jobs:
         - linux: libraries
           posargs: 'rolldice -v'
         - macos: libraries
-          posargs: 'opj_compress -h'
+          posargs: 'which opj_compress'
         - linux: libraries
           posargs: 'bcal -h'
           libraries:

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
     cache-{setup,verify}
 
 [testenv]
-whitelist_externals =
+allowlist_externals =
     python
     conda
     bcal

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,10 @@ envlist =
 whitelist_externals =
     python
     conda
+    bcal
+    dot
+    opj_compress
+    rolldice
 skip_install = true
 commands =
     # Check the python version is as expected

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ allowlist_externals =
     conda
     bcal
     dot
-    opj_compress
     rolldice
+    which
 skip_install = true
 commands =
     # Check the python version is as expected


### PR DESCRIPTION
Externals now need to be listed, and changed graphviz to openjpeg on brew because it was causing a path linking error which was outside the scope of this workflow.