### PR TITLE
Fix coverage upload for astropy

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -181,4 +181,5 @@ jobs:
         if: ${{ contains(matrix.coverage, 'codecov') && matrix.pytest == 'true' }}
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          verbose: true

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -181,5 +181,6 @@ jobs:
         if: ${{ contains(matrix.coverage, 'codecov') && matrix.pytest == 'true' }}
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           verbose: true


### PR DESCRIPTION
astropy coverage upload keeps failing. This patch shows you the settings we had before. You don't need a token for public repo. And if you cannot accept this patch, please suggest an alternative. Otherwise I am not sure what to do.