### PR TITLE
Update deprecated input to `pypa/gh-action-pypi-publish`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -230,7 +230,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}
-          repository_url: ${{ inputs.repository_url }}
+          repository-url: ${{ inputs.repository_url }}
       - uses: OpenAstronomy/publish-wheels-anaconda@main
         if: ${{ inputs.upload_to_anaconda }}
         with:

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}
-          repository_url: ${{ inputs.repository_url }}
+          repository-url: ${{ inputs.repository_url }}
       - uses: OpenAstronomy/publish-wheels-anaconda@main
         if: ${{ inputs.upload_to_anaconda }}
         with:


### PR DESCRIPTION
Was showing a warning: ``Warning: Input 'repository_url' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `repository-url` instead.`` (https://github.com/OpenAstronomy/github-actions-workflows/actions/runs/4409668388/jobs/7726238735#step:9:1)