### PR TITLE
add Python version to name

### DIFF
--- a/tools/tox_matrix.py
+++ b/tools/tox_matrix.py
@@ -130,7 +130,7 @@ def get_matrix_item(env, global_libraries, global_string_parameters,
         item["python_version"] = env.get("default_python") or default_python
 
     # set name
-    item["name"] = env.get("name") or f'{item["toxenv"]} ({item["os"]})'
+    item["name"] = env.get("name") or f'{item["toxenv"]} (Python {item["python_version"]} on {item["os"]})'
 
     # set pytest_flag
     item["pytest_flag"] = ""


### PR DESCRIPTION
this might cause some issues with required checks in repository branch protection settings (which look for an exact name match) so perhaps should be cause for a bump to `@v2`