### PR TITLE
Upload to codecov, even when some tests fail

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -194,7 +194,8 @@ jobs:
         shell: sh
 
       - name: Upload to Codecov
-        if: ${{ contains(matrix.coverage, 'codecov') && matrix.pytest == 'true' }}
+        # Even if tox fails, upload coverage
+        if: ${{ (success() || failure()) && contains(matrix.coverage, 'codecov') && matrix.pytest == 'true' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixes https://github.com/OpenAstronomy/github-actions-workflows/issues/81. I think it's safe to always run the codecov step, no matter what happens in the tox step. If no coverage file is generated, codecov just won't upload or report anything.