### PR TITLE
use built-in concurrency block

### DIFF
--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -2,6 +2,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release_default:
     uses: ./.github/workflows/publish.yml

--- a/.github/workflows/test_publish_pure_python.yml
+++ b/.github/workflows/test_publish_pure_python.yml
@@ -2,6 +2,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     uses: ./.github/workflows/publish_pure_python.yml

--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -2,6 +2,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_pyos:
     uses: ./.github/workflows/tox.yml


### PR DESCRIPTION
this keeps workflows from duplicating running on the same `ref`