### PR TITLE
Only set CIBW testing env vars if workflow input is given

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,6 +143,18 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all
+      - name: Configure cibuildwheel
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.test_extras }}" ];
+          then
+            echo "CIBW_TEST_EXTRAS=${{ inputs.test_extras }}" >> $GITHUB_ENV
+          fi
+          if [ -n "${{ inputs.test_command }}" ];
+          then
+            echo "CIBW_TEST_COMMAND=${{ inputs.test_command }}" >> $GITHUB_ENV
+          fi
+          cat $GITHUB_ENV
       - uses: actions/setup-python@v4
         if: ${{ inputs.env != '' }}
         with:
@@ -164,8 +176,6 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
           CIBW_ARCHS: ${{ matrix.CIBW_ARCHS }}
-          CIBW_TEST_EXTRAS: ${{ inputs.test_extras }}
-          CIBW_TEST_COMMAND: ${{ inputs.test_command }}
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*

--- a/docs/source/publish.rst
+++ b/docs/source/publish.rst
@@ -73,12 +73,14 @@ test_extras
 
 Any ``extras_requires`` modifier that should be used to install the
 package for testing. Default is none.
+If not set, cibuildwheel will use any ``test-extras`` configured in ``pyproject.toml``.
 
 test_command
 ^^^^^^^^^^^^
 
 The command to run to test the package. Will be run in a temporary
 directory. Default is no testing.
+If not set, cibuildwheel will use any ``test-command`` configured in ``pyproject.toml``.
 
 env
 ^^^


### PR DESCRIPTION
Check if the `test_extras` or `test_command` workflow inputs are given, and only set the CIBW environment variables if they are. Therefore cibuildwheel can fall back to configuration in 
`pyproject.toml`.

Closes #126
