### PR TITLE
ignore changes to other workflows when dispatching tests

### DIFF
--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -1,6 +1,12 @@
 on:
   push:
+    paths:
+      - .github/workflows/publish.yml
+      - .github/workflows/test_publish.yml
   pull_request:
+    paths:
+      - .github/workflows/publish.yml
+      - .github/workflows/test_publish.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_publish_pure_python.yml
+++ b/.github/workflows/test_publish_pure_python.yml
@@ -1,6 +1,12 @@
 on:
   push:
+    paths:
+      - .github/workflows/publish_pure_python.yml
+      - .github/workflows/test_publish_pure_python.yml
   pull_request:
+    paths:
+      - .github/workflows/publish_pure_python.yml
+      - .github/workflows/test_publish_pure_python.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -1,6 +1,12 @@
 on:
   push:
+    paths:
+      - .github/workflows/tox.yml
+      - .github/workflows/test_tox.yml
   pull_request:
+    paths:
+      - .github/workflows/tox.yml
+      - .github/workflows/test_tox.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
only run `test_tox.yml`, `test_publish.yml`, and `test_publish_pure_python.yml` when their respective workflows change