### PR TITLE
Allow checkout ref to be customized

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,6 +86,11 @@ on:
         required: false
         default: true
         type: boolean
+      checkout_ref:
+        description: The ref to checkout
+        required: false
+        default: ''
+        type: string
     secrets:
       pypi_token:
         required: false
@@ -138,6 +143,7 @@ jobs:
           fetch-depth: 0
           lfs: true
           submodules: ${{ inputs.submodules }}
+          ref: ${{ inputs.checkout_ref }}
       - name: Set up QEMU
         if: ${{ matrix.CIBW_ARCHS == 'aarch64' }}
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -73,6 +73,11 @@ on:
         required: false
         default: '3.x'
         type: string
+      checkout_ref:
+        description: The ref to checkout
+        required: false
+        default: ''
+        type: string
     secrets:
       pypi_token:
         required: false
@@ -105,6 +110,7 @@ jobs:
           fetch-depth: 0
           lfs: true
           submodules: ${{ inputs.submodules }}
+          ref: ${{ inputs.checkout_ref }}
       - name: Install dependencies
         if: ${{ inputs.libraries != '' }}
         uses: ConorMacBride/install-package@main

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -97,6 +97,11 @@ on:
         required: false
         default: true
         type: boolean
+      checkout_ref:
+        description: The ref to checkout
+        required: false
+        default: ''
+        type: string
     secrets:
       CODECOV_TOKEN:
         description: Codecov upload token (for private repositories only)
@@ -147,6 +152,7 @@ jobs:
           fetch-depth: 0
           lfs: true
           submodules: ${{ inputs.submodules }}
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Cache ${{ matrix.cache_key }}
         if: ${{ matrix.cache-path != '' && matrix.cache-key != '' }}


### PR DESCRIPTION
I am working on a package (astropy-iers-data) for which I would like to have completely automated releases - this involves having a workflow where I update some files automatically, push a commit to the repository, push a tag to the repository, and then run the publish workflow here. However, by default, the checkout step doesn't see the latest commit I created in the workflow, so I need to be able to pass a checkout ref to the checkout step. I may have missed a better way to do this though?