### PR TITLE
Allow quotes in `test_command` input

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,9 +156,16 @@ jobs:
           then
             echo "CIBW_TEST_EXTRAS=${{ inputs.test_extras }}" >> $GITHUB_ENV
           fi
-          if [ -n "${{ inputs.test_command }}" ];
+          set +e
+          IFS='' read -r -d '' test_command <<"EOF"
+          ${{ inputs.test_command }}
+          EOF
+          set -e
+          if [ -n "$test_command" ];
           then
-            echo "CIBW_TEST_COMMAND=${{ inputs.test_command }}" >> $GITHUB_ENV
+            echo "CIBW_TEST_COMMAND<<EOF" >> $GITHUB_ENV
+            echo $(echo $test_command | tr -d '\n') >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
           fi
           cat $GITHUB_ENV
       - uses: actions/setup-python@v4


### PR DESCRIPTION
As highlighted in #143, `test_command` fails when double quotes exist.

When GitHub does a string replacement for an example test command of `echo aaa "bbb" ccc` it causes our bash script to include bad syntax like:

```bash
if [ -n "echo aaa "bbb" ccc"];
...
```

The solution proposed in this PR is to load the `test_command` input into a variable like:

```bash
IFS='' read -r -d '' test_command <<"EOF"
echo aaa "bbb" ccc
EOF
if [ -n "$test_command"];
...
```

That way all characters in the test command will be interpreted literally.

You can see [here](https://github.com/OpenAstronomy/github-actions-workflows/actions/runs/5547681333/jobs/10129647212#step:1:51), [here](https://github.com/OpenAstronomy/github-actions-workflows/actions/runs/5547681333/jobs/10129647212#step:4:22) and [here](https://github.com/OpenAstronomy/github-actions-workflows/actions/runs/5547681333/jobs/10129647212#step:7:207) it parsing a `test_command` with various quotes correctly.

Please feel free to push any updates to this PR and merge. (I'm away from a week so could be slow to respond.)