### PR TITLE
Allow pre-releases of Python

### DIFF
--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -176,3 +176,9 @@ jobs:
       envs: |
         - linux: py310-linux
           pytest-results-summary: true
+
+  test_prereleases:
+    uses: ./.github/workflows/tox.yml
+    with:
+      envs: |
+        - linux: py312

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -181,6 +181,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
+          allow-prereleases: true
 
       - name: Setup conda
         if: ${{ matrix.conda == 'true' }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,6 @@ build:
     python: "3.11"
 
 python:
-  system_packages: false
   install:
     - requirements: docs/requirements.txt
 


### PR DESCRIPTION
I don't think there's any harm in enabling this by default? It just has the effect of making Python 3.12 work when it didn't but shouldn't affect other versions?