### PR TITLE
Try to block artifact uploads when unnecessary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,6 +190,8 @@ jobs:
           CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
           CIBW_ARCHS: ${{ matrix.CIBW_ARCHS }}
       - uses: actions/upload-artifact@v3
+        if: |
+          needs.targets.outputs.upload_to_pypi == 'true' || inputs.upload_to_anaconda
         with:
           path: dist/*
 
@@ -230,6 +232,8 @@ jobs:
           test_command: ${{ inputs.test_command }}
           pure_python_wheel: false
       - uses: actions/upload-artifact@v3
+        if: |
+          needs.targets.outputs.upload_to_pypi == 'true' || inputs.upload_to_anaconda
         with:
           path: dist/*
 


### PR DESCRIPTION
Attempt to fix #159.

This prevents artifact uploads when the wheels will not be uploaded to PyPi or anaconda.