### PR TITLE
Make sure build_sdist requires targets as it is needed for the artifact upload condition

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -197,6 +197,7 @@ jobs:
 
   build_sdist:
     name: Build source distribution
+    needs: [targets]
     if: ${{ inputs.sdist }}
     runs-on: ${{ inputs.sdist-runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}


### PR DESCRIPTION
This fixes https://github.com/OpenAstronomy/github-actions-workflows/issues/167

The issue was that the artifact upload condition in the sdist job is:

```
      - uses: actions/upload-artifact@v3
        if: |
          needs.targets.outputs.upload_to_pypi == 'true' || inputs.upload_to_anaconda
```

but the sdist job didn't technically require targets so ``needs.targets.outputs.upload_to_pypi`` wasn't set correctly. I don't quite understand why this wasn't an issue before, maybe GitHub got more strict about this, or maybe it is a race condition.

This also explains why astropy nightlies were working fine - the anaconda upload condition is separate and doesn't rely on ``needs.targets``. 