### PR TITLE
Upgrade `upload-artifact` and `download-artifact` actions from `v3` to `v4`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,7 +113,7 @@ jobs:
       - run: python -m pip install PyYAML click
       - run: echo $LOAD_BUILD_TARGETS_SCRIPT | base64 --decode > load_build_targets.py
         env:
-          LOAD_BUILD_TARGETS_SCRIPT: aW1wb3J0IGpzb24KaW1wb3J0IG9zCgppbXBvcnQgY2xpY2sKaW1wb3J0IHlhbWwKCk1BQ0hJTkVfVFlQRSA9IHsKICAgICJsaW51eCI6ICJ1YnVudHUtbGF0ZXN0IiwKICAgICJtYWNvcyI6ICJtYWNvcy1sYXRlc3QiLAogICAgIndpbmRvd3MiOiAid2luZG93cy1sYXRlc3QiLAp9CgpDSUJXX0JVSUxEID0gb3MuZW52aXJvbi5nZXQoIkNJQldfQlVJTEQiLCAiKiIpCkNJQldfQVJDSFMgPSBvcy5lbnZpcm9uLmdldCgiQ0lCV19BUkNIUyIsICJhdXRvIikKCgpAY2xpY2suY29tbWFuZCgpCkBjbGljay5vcHRpb24oIi0tdGFyZ2V0cyIsIGRlZmF1bHQ9IiIpCmRlZiBsb2FkX2J1aWxkX3RhcmdldHModGFyZ2V0cyk6CiAgICAiIiJTY3JpcHQgdG8gbG9hZCBjaWJ1aWxkd2hlZWwgdGFyZ2V0cyBmb3IgR2l0SHViIEFjdGlvbnMgd29ya2Zsb3cuIiIiCiAgICAjIExvYWQgbGlzdCBvZiB0YXJnZXRzCiAgICB0YXJnZXRzID0geWFtbC5sb2FkKHRhcmdldHMsIExvYWRlcj15YW1sLkJhc2VMb2FkZXIpCiAgICBwcmludChqc29uLmR1bXBzKHRhcmdldHMsIGluZGVudD0yKSkKCiAgICAjIENyZWF0ZSBtYXRyaXgKICAgIG1hdHJpeCA9IHsiaW5jbHVkZSI6IFtdfQogICAgZm9yIHRhcmdldCBpbiB0YXJnZXRzOgogICAgICAgIG1hdHJpeFsiaW5jbHVkZSJdLmFwcGVuZChnZXRfbWF0cml4X2l0ZW0odGFyZ2V0KSkKCiAgICAjIE91dHB1dCBtYXRyaXgKICAgIHByaW50KGpzb24uZHVtcHMobWF0cml4LCBpbmRlbnQ9MikpCiAgICB3aXRoIG9wZW4ob3MuZW52aXJvblsiR0lUSFVCX09VVFBVVCJdLCAiYSIpIGFzIGY6CiAgICAgICAgZi53cml0ZShmIm1hdHJpeD17anNvbi5kdW1wcyhtYXRyaXgpfVxuIikKCgpkZWYgZ2V0X29zKHRhcmdldCk6CiAgICBpZiAibWFjb3MiIGluIHRhcmdldDoKICAgICAgICByZXR1cm4gTUFDSElORV9UWVBFWyJtYWNvcyJdCiAgICBpZiAid2luIiBpbiB0YXJnZXQ6CiAgICAgICAgcmV0dXJuIE1BQ0hJTkVfVFlQRVsid2luZG93cyJdCiAgICByZXR1cm4gTUFDSElORV9UWVBFWyJsaW51eCJdCgoKZGVmIGdldF9jaWJ3X2J1aWxkKHRhcmdldCk6CiAgICBpZiB0YXJnZXQgaW4geyJsaW51eCIsICJtYWNvcyIsICJ3aW5kb3dzIn06CiAgICAgICAgcmV0dXJuIENJQldfQlVJTEQKICAgIHJldHVybiB0YXJnZXQKCgpkZWYgZ2V0X2NpYndfYXJjaHModGFyZ2V0KToKICAgIGZvciBhcmNoIGluIFsiYWFyY2g2NCIsICJhcm02NCIsICJ1bml2ZXJzYWwyIl06CiAgICAgICAgaWYgdGFyZ2V0LmVuZHN3aXRoKGFyY2gpOgogICAgICAgICAgICByZXR1cm4gYXJjaAogICAgcmV0dXJuIENJQldfQVJDSFMKCgpkZWYgZ2V0X21hdHJpeF9pdGVtKHRhcmdldCk6CiAgICByZXR1cm4gewogICAgICAgICJ0YXJnZXQiOiB0YXJnZXQsCiAgICAgICAgIm9zIjogZ2V0X29zKHRhcmdldCksCiAgICAgICAgIkNJQldfQlVJTEQiOiBnZXRfY2lid19idWlsZCh0YXJnZXQpLAogICAgICAgICJDSUJXX0FSQ0hTIjogZ2V0X2NpYndfYXJjaHModGFyZ2V0KSwKICAgIH0KCgppZiBfX25hbWVfXyA9PSAiX19tYWluX18iOgogICAgbG9hZF9idWlsZF90YXJnZXRzKCkK
+          LOAD_BUILD_TARGETS_SCRIPT: aW1wb3J0IGpzb24KaW1wb3J0IG9zCmltcG9ydCByZQoKaW1wb3J0IGNsaWNrCmltcG9ydCB5YW1sCgpNQUNISU5FX1RZUEUgPSB7CiAgICAibGludXgiOiAidWJ1bnR1LWxhdGVzdCIsCiAgICAibWFjb3MiOiAibWFjb3MtbGF0ZXN0IiwKICAgICJ3aW5kb3dzIjogIndpbmRvd3MtbGF0ZXN0IiwKfQoKQ0lCV19CVUlMRCA9IG9zLmVudmlyb24uZ2V0KCJDSUJXX0JVSUxEIiwgIioiKQpDSUJXX0FSQ0hTID0gb3MuZW52aXJvbi5nZXQoIkNJQldfQVJDSFMiLCAiYXV0byIpCgoKQGNsaWNrLmNvbW1hbmQoKQpAY2xpY2sub3B0aW9uKCItLXRhcmdldHMiLCBkZWZhdWx0PSIiKQpkZWYgbG9hZF9idWlsZF90YXJnZXRzKHRhcmdldHMpOgogICAgIiIiU2NyaXB0IHRvIGxvYWQgY2lidWlsZHdoZWVsIHRhcmdldHMgZm9yIEdpdEh1YiBBY3Rpb25zIHdvcmtmbG93LiIiIgogICAgIyBMb2FkIGxpc3Qgb2YgdGFyZ2V0cwogICAgdGFyZ2V0cyA9IHlhbWwubG9hZCh0YXJnZXRzLCBMb2FkZXI9eWFtbC5CYXNlTG9hZGVyKQogICAgcHJpbnQoanNvbi5kdW1wcyh0YXJnZXRzLCBpbmRlbnQ9MikpCgogICAgIyBDcmVhdGUgbWF0cml4CiAgICBtYXRyaXggPSB7ImluY2x1ZGUiOiBbXX0KICAgIGZvciB0YXJnZXQgaW4gdGFyZ2V0czoKICAgICAgICBtYXRyaXhbImluY2x1ZGUiXS5hcHBlbmQoZ2V0X21hdHJpeF9pdGVtKHRhcmdldCkpCgogICAgIyBPdXRwdXQgbWF0cml4CiAgICBwcmludChqc29uLmR1bXBzKG1hdHJpeCwgaW5kZW50PTIpKQogICAgd2l0aCBvcGVuKG9zLmVudmlyb25bIkdJVEhVQl9PVVRQVVQiXSwgImEiKSBhcyBmOgogICAgICAgIGYud3JpdGUoZiJtYXRyaXg9e2pzb24uZHVtcHMobWF0cml4KX1cbiIpCgoKZGVmIGdldF9vcyh0YXJnZXQpOgogICAgaWYgIm1hY29zIiBpbiB0YXJnZXQ6CiAgICAgICAgcmV0dXJuIE1BQ0hJTkVfVFlQRVsibWFjb3MiXQogICAgaWYgIndpbiIgaW4gdGFyZ2V0OgogICAgICAgIHJldHVybiBNQUNISU5FX1RZUEVbIndpbmRvd3MiXQogICAgcmV0dXJuIE1BQ0hJTkVfVFlQRVsibGludXgiXQoKCmRlZiBnZXRfY2lid19idWlsZCh0YXJnZXQpOgogICAgaWYgdGFyZ2V0IGluIHsibGludXgiLCAibWFjb3MiLCAid2luZG93cyJ9OgogICAgICAgIHJldHVybiBDSUJXX0JVSUxECiAgICByZXR1cm4gdGFyZ2V0CgoKZGVmIGdldF9jaWJ3X2FyY2hzKHRhcmdldCk6CiAgICBmb3IgYXJjaCBpbiBbImFhcmNoNjQiLCAiYXJtNjQiLCAidW5pdmVyc2FsMiJdOgogICAgICAgIGlmIHRhcmdldC5lbmRzd2l0aChhcmNoKToKICAgICAgICAgICAgcmV0dXJuIGFyY2gKICAgIHJldHVybiBDSUJXX0FSQ0hTCgoKZGVmIGdldF9hcnRpZmFjdF9uYW1lKHRhcmdldCk6CiAgICBhcnRpZmFjdF9uYW1lID0gcmUuc3ViKHIiW1xcIC86PD58Kj9cIiddIiwgIi0iLCB0YXJnZXQpCiAgICBhcnRpZmFjdF9uYW1lID0gcmUuc3ViKHIiLSsiLCAiLSIsIGFydGlmYWN0X25hbWUpCiAgICByZXR1cm4gYXJ0aWZhY3RfbmFtZQoKCmRlZiBnZXRfbWF0cml4X2l0ZW0odGFyZ2V0KToKICAgIHJldHVybiB7CiAgICAgICAgInRhcmdldCI6IHRhcmdldCwKICAgICAgICAib3MiOiBnZXRfb3ModGFyZ2V0KSwKICAgICAgICAiQ0lCV19CVUlMRCI6IGdldF9jaWJ3X2J1aWxkKHRhcmdldCksCiAgICAgICAgIkNJQldfQVJDSFMiOiBnZXRfY2lid19hcmNocyh0YXJnZXQpLAogICAgICAgICJhcnRpZmFjdC1uYW1lIjogZ2V0X2FydGlmYWN0X25hbWUodGFyZ2V0KSwKICAgIH0KCgppZiBfX25hbWVfXyA9PSAiX19tYWluX18iOgogICAgbG9hZF9idWlsZF90YXJnZXRzKCkK
       - id: set-outputs
         run: python load_build_targets.py --targets "${{ inputs.targets }}"
         shell: sh
@@ -189,10 +189,11 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
           CIBW_ARCHS: ${{ matrix.CIBW_ARCHS }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: |
           needs.targets.outputs.upload_to_pypi == 'true' || inputs.upload_to_anaconda
         with:
+          name: "dist-${{ matrix.artifact-name }}"
           path: dist/*
 
   build_sdist:
@@ -232,10 +233,11 @@ jobs:
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
           pure_python_wheel: false
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: |
           needs.targets.outputs.upload_to_pypi == 'true' || inputs.upload_to_anaconda
         with:
+          name: dist-sdist
           path: dist/*
 
   upload:
@@ -250,10 +252,11 @@ jobs:
       needs.build_wheels.result != 'failure' &&
       needs.build_sdist.result != 'failure'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: dist-*
           path: dist
+          merge-multiple: true
       - uses: pypa/gh-action-pypi-publish@release/v1
         name: Upload to PyPI
         if: ${{ needs.targets.outputs.upload_to_pypi == 'true' }}

--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -164,7 +164,7 @@ jobs:
     needs: [test_artifact_upload]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact-upload-(ubuntu-latest)
           path: .

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -213,7 +213,7 @@ jobs:
         shell: sh
 
       - if: ${{ (success() || failure()) && matrix.artifact-path != '' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-path }}

--- a/tools/load_build_targets.py
+++ b/tools/load_build_targets.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 import click
 import yaml
@@ -54,12 +55,19 @@ def get_cibw_archs(target):
     return CIBW_ARCHS
 
 
+def get_artifact_name(target):
+    artifact_name = re.sub(r"[\\ /:<>|*?\"']", "-", target)
+    artifact_name = re.sub(r"-+", "-", artifact_name)
+    return artifact_name
+
+
 def get_matrix_item(target):
     return {
         "target": target,
         "os": get_os(target),
         "CIBW_BUILD": get_cibw_build(target),
         "CIBW_ARCHS": get_cibw_archs(target),
+        "artifact-name": get_artifact_name(target),
     }
 
 


### PR DESCRIPTION
The `v3` to `v4` upgrade introduces three breaking changes: https://github.com/actions/upload-artifact#breaking-changes

Two of them are not relevant as we don't support self-hosted runners, and we only ever save one artifact per job.

The other is that the artifacts are now immutable -- we cannot keep uploading wheels to the same artifact in each job. I've updated the workflow to write a separate artifact per build job and merge them in the upload job.

Supersedes #173 and #174.