### PR TITLE
Run workflow utils with Python 3.12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - run: python -m pip install PyYAML click
       - run: echo $LOAD_BUILD_TARGETS_SCRIPT | base64 --decode > load_build_targets.py
         env:
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: ${{ inputs.env != '' }}
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - id: set-env
         if: ${{ inputs.env != '' }}
         run: |
@@ -206,7 +206,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: ${{ inputs.env != '' }}
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - id: set-env
         if: ${{ inputs.env != '' }}
         run: |

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: ${{ inputs.env != '' }}
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - id: set-env
         if: ${{ inputs.env != '' }}
         run: |

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - run: python -m pip install PyYAML click
       - run: echo $TOX_MATRIX_SCRIPT | base64 --decode > tox_matrix.py
         env:


### PR DESCRIPTION
Due to https://github.com/actions/setup-python/issues/808 we can't install Python 3.9 for the workflow utils. However, Python 3.12 has builds for all the current GitHub-hosted runners. It's probably a good idea to keep this version more up-to-date.

Fixes https://github.com/astropy/astropy/issues/15974#issuecomment-1961542451
Fixes https://github.com/astropy/astropy/pull/16081