### PR TITLE
add docs explaining how to install libraries within build environment

### DIFF
--- a/docs/source/publish.rst
+++ b/docs/source/publish.rst
@@ -125,7 +125,7 @@ extra.
     [tool.cibuildwheel.macos]
     before-build = "brew install fftw"
 
-  or by setting the ``CIBW_BEFORE_BUILD_MACOS`` environment variable:
+  or by [setting a ``CIBW_BEFORE_BUILD_*`` environment variable](https://cibuildwheel.pypa.io/en/stable/options/#before-build):
 
   .. code:: yaml
 

--- a/docs/source/publish.rst
+++ b/docs/source/publish.rst
@@ -115,7 +115,17 @@ extra.
   These libraries are only installed on the host Linux machine.
   To install libraries or packages within the build environment, alter the
   ``cibuildwheel`` configuration to add an install command before the build,
-  such as by setting the ``CIBW_BEFORE_BUILD_MACOS`` environment variable:
+  such as adding an entry to the ``tool.cibuildwheel`` table in ``pyproject.toml``:
+
+  .. code:: toml
+
+    [tool.cibuildwheel.linux]
+    before-build = "apt install libfftw3-dev"
+
+    [tool.cibuildwheel.macos]
+    before-build = "brew install fftw"
+
+  or by setting the ``CIBW_BEFORE_BUILD_MACOS`` environment variable:
 
   .. code:: yaml
 
@@ -130,16 +140,6 @@ extra.
           targets: |
             - cp3*-manylinux_x86_64
             - cp3*-macosx_x86_64
-
-  or by adding an entry to the ``tool.cibuildwheel`` table in ``pyproject.toml``:
-
-  .. code:: toml
-
-    [tool.cibuildwheel.linux]
-    before-build = "apt install libfftw3-dev"
-
-    [tool.cibuildwheel.macos]
-    before-build = "brew install fftw"
 
 upload_to_pypi
 ^^^^^^^^^^^^^^

--- a/docs/source/publish.rst
+++ b/docs/source/publish.rst
@@ -111,6 +111,36 @@ Packages needed to build the source distribution for testing. Must be a
 string of space-separated apt packages. Default is install nothing
 extra.
 
+.. warning::
+  These libraries are only installed on the host Linux machine.
+  To install libraries or packages within the build environment, alter the
+  ``cibuildwheel`` configuration to add an install command before the build,
+  such as by setting the ``CIBW_BEFORE_BUILD_MACOS`` environment variable:
+
+  .. code:: yaml
+
+    jobs:
+      build:
+        uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+        with:
+          env: |
+            CIBW_BEFORE_BUILD_LINUX: apt install libfftw3-dev
+            CIBW_BEFORE_BUILD_MACOS: brew install fftw
+            FFTW_DIR: /opt/homebrew/opt/fftw/lib/
+          targets: |
+            - cp3*-manylinux_x86_64
+            - cp3*-macosx_x86_64
+
+  or by adding an entry to the ``tool.cibuildwheel`` table in ``pyproject.toml``:
+
+  .. code:: toml
+
+    [tool.cibuildwheel.linux]
+    before-build = "apt install libfftw3-dev"
+
+    [tool.cibuildwheel.macos]
+    before-build = "brew install fftw"
+
 upload_to_pypi
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
see https://github.com/OpenAstronomy/github-actions-workflows/issues/201#issuecomment-2110291134

docs built at https://github-actions-workflows--202.org.readthedocs.build/en/202/publish.html#libraries
[<img width="588" alt="image" src="https://github.com/OpenAstronomy/github-actions-workflows/assets/16024299/afcc8228-118d-41a7-9d80-684faa4fccee">](https://github-actions-workflows--202.org.readthedocs.build/en/202/publish.html#libraries)
