### PR TITLE
Update codecov description because token is now required even for public repo

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -109,7 +109,7 @@ on:
         type: string
     secrets:
       CODECOV_TOKEN:
-        description: Codecov upload token (for private repositories only)
+        description: Codecov upload token
         required: false
 
 jobs:


### PR DESCRIPTION
See https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov