### PR TITLE
Revert splitting out of coverage step

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -223,38 +223,9 @@ jobs:
         with:
           paths: "**/results.xml"
 
-      - name: Upload coverage to artifacts
+      - name: Upload to Codecov
         # Even if tox fails, upload coverage
         if: ${{ (success() || failure()) && contains(matrix.coverage, 'codecov') && matrix.pytest == 'true' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage_${{ matrix.toxenv }}
-          path: coverage.xml
-          if-no-files-found: error
-
-  upload-codecov:
-    needs: [tox]
-    permissions:
-      contents: none
-    runs-on: ubuntu-latest
-    name: Upload Coverage
-    steps:
-
-      - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: coverage
-          pattern: coverage_*
-          merge-multiple: false
-
-      - name: Display structure of downloaded files
-        run: ls -R
-
-      - name: Upload report to Codecov
-        if: ${{ hashFiles('coverage/') != '' }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: coverage
-          fail_ci_if_error: true
-          verbose: true


### PR DESCRIPTION
This reverts https://github.com/OpenAstronomy/github-actions-workflows/pull/199 as it is causing CI to fail in e.g. glue and reproject and other projects. We should make sure we test any follow-up repeat PR more extensively to make sure there are no more issues.