### PR TITLE
[IGNORE] Trying to replicate behavior seen in sunpy

### DIFF
--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -30,7 +30,19 @@ jobs:
         - cp311-macosx_x86_64
         - cp312-macosx_arm64
         - cp3?-win_amd64
-        - cp312-manylinux_aarch64
+      timeout-minutes: 30
+  release-double:
+    uses: ./.github/workflows/publish.yml
+    with:
+      upload_to_anaconda: true
+      anaconda_user: none
+      anaconda_package: none
+      anaconda_keep_n_latest: 1
+      sdist: false
+      test_extras: test
+      test_command: pytest --pyargs test_package
+      targets: |
+        - cp3{10,11,12}-manylinux_aarch64
       timeout-minutes: 30
   release_sdist_only:
     uses: ./.github/workflows/publish.yml


### PR DESCRIPTION
Trying to replicate some odd behavior seen on the sunpy repo:

https://github.com/sunpy/sunpy/actions/runs/9914510837/job/27394432272

Having two seperate publish runs fail on the aarch64 but the normal builds pass.

Combining them into one step, they pass:

https://github.com/sunpy/sunpy/actions/runs/9915732864/job/27397307423

The upload step checks that each wheel is "valid", so I am unsure how to reproduce this on the CI here. 
 
