### PR TITLE
Disable attestations in pypi-publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -264,6 +264,7 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           repository-url: ${{ inputs.repository_url }}
+          attestations: false  # https://github.com/pypi/warehouse/issues/11096
       - uses: OpenAstronomy/publish-wheels-anaconda@main
         if: ${{ inputs.upload_to_anaconda }}
         with:

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -141,6 +141,7 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
           repository-url: ${{ inputs.repository_url }}
+          attestations: false  # https://github.com/pypi/warehouse/issues/11096
       - uses: OpenAstronomy/publish-wheels-anaconda@main
         if: ${{ inputs.upload_to_anaconda }}
         with:

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -90,6 +90,8 @@ jobs:
     name: Build source and wheel distribution
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      id-token: write
     steps:
       - uses: actions/setup-python@v5
         if: ${{ inputs.env != '' }}


### PR DESCRIPTION
This might fix https://github.com/OpenAstronomy/github-actions-workflows/issues/136 for now - some of my packages are currently failing at the upload step. I'll test this out to confirm it works.