### PR TITLE
build sdist with python 3.12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -238,6 +238,7 @@ jobs:
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
           pure_python_wheel: false
+          python-version: '3.12'
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         if: |
           needs.targets.outputs.upload_to_pypi == 'true' || inputs.upload_to_anaconda


### PR DESCRIPTION
This is pretty much a bandaid solution.

Even though the `build_sdist` job in the `publish` workflow sets up python with 3.12:
https://github.com/OpenAstronomy/github-actions-workflows/blob/3b829fea7696d1d48e74177c162e2435a208d0e1/.github/workflows/publish.yml#L214
It does not provide a python version to `OpenAstronomy/build-python-dist` which is causing it to install and setup python 3.13 (as it [defaults](https://github.com/OpenAstronomy/build-python-dist/blob/88c00a7d9449194bb368a16938b90f28dc813d72/action.yml#L25) to 3.x).

This is causing build failures for a package that has a python upper pin that prevents 3.13 (as the CI is otherwise unaware of this pin) due to the 3.x job now defaulting to 3.13:
https://github.com/spacetelescope/jwst/actions/runs/13034242395/job/36361396551?pr=9081

This PR doesn't address the root cause (the CI being unaware of the python pin) but does pass the 3.12 version on to `OpenAstronomy/build-python-dist` which should fix the immediate failures for that package.