### PR TITLE
remove `--upgrade` from `tox` install step to prevent clobbering conda-installed `tox`

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -217,7 +217,7 @@ jobs:
         uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8  # v3
 
       - name: Install tox
-        run: python -m pip install --upgrade tox ${{ matrix.toxdeps }}
+        run: python -m pip install tox ${{ matrix.toxdeps }}
 
       - run: python -m tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.pytest_flag }} ${{ matrix.posargs }}
 

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -217,7 +217,7 @@ jobs:
         uses: pyvista/setup-headless-display-action@52bda06d59c0fc422fc2512c9c670bf6b66616f8  # v3
 
       - name: Install tox
-        run: python -m pip install tox ${{ matrix.toxdeps }}
+        run: python -m pip install --upgrade -vv tox ${{ matrix.toxdeps }}
 
       - run: python -m tox -e ${{ matrix.toxenv }} ${{ matrix.toxargs }} -- ${{ matrix.pytest_flag }} ${{ matrix.posargs }}
 


### PR DESCRIPTION
> this error in the test setup is due to an outdated version of `tox`:
> https://github.com/spacetelescope/wfc3tools/actions/runs/15420719087/job/43394794514?pr=90#step:10:10
> ```
> ERROR: pyproject.toml file found.
> To use a PEP 517 build-backend you are required to configure tox to use an isolated_build:
> https://tox.readthedocs.io/en/latest/example/package.html
> ```
> 
> The version of `tox` installed with `setup-micromamba` IS up-to-date (`tox 4.26.0`), but then the `Install Tox` step overrides that with `tox 3.28.0` because it calls `pip install tox` with `--upgrade`. I'm making an upstream PR to the OpenAstronomy workflow to remove `--upgrade`

https://github.com/spacetelescope/wfc3tools/pull/90#issuecomment-2944697540