### PR TITLE
ENH: add support for PEP 735 dependency-groups via a new workflow input `test_groups`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: true
         type: boolean
+      test_groups:
+        description: PEP 735 dependency groups that should be installed for testing
+        required: false
+        default: ''
+        type: string
       test_extras:
         description: Any extras_requires modifier that should be used to install the package for testing
         required: false
@@ -154,12 +159,20 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
         with:
           platforms: all
+      - name: Parse dependency groups
+        shell: bash
+        run: |
+          echo "space_sep_groups=$( python -c "print('${{ inputs.test_groups }}'.replace(',', ' '))" )" >> "$GITHUB_ENV"
       - name: Configure cibuildwheel
         shell: bash
         run: |
           if [ -n "${{ inputs.test_extras }}" ];
           then
             echo "CIBW_TEST_EXTRAS=${{ inputs.test_extras }}" >> $GITHUB_ENV
+          fi
+          if [ -n "${{ inputs.test_groups }}" ];
+          then
+            echo "CIBW_TEST_GROUPS=$space_sep_groups" >> $GITHUB_ENV
           fi
           set +e
           IFS='' read -r -d '' test_command <<"EOF"
@@ -233,8 +246,9 @@ jobs:
         with:
           apt: ${{ inputs.libraries }}
       - id: build
-        uses: OpenAstronomy/build-python-dist@bbb0e1c5b132893999ea56d77bd4b526e0097c7d  # v1.0.1
+        uses: OpenAstronomy/build-python-dist@9a4b2bd6bda5c48ef3c12b53504ee2263ed032e3  # v1.1.0
         with:
+          test_groups: ${{ inputs.test_groups }}
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
           pure_python_wheel: false

--- a/.github/workflows/publish_pure_python.yml
+++ b/.github/workflows/publish_pure_python.yml
@@ -3,6 +3,11 @@ name: Build and publish pure Python package
 on:
   workflow_call:
     inputs:
+      test_groups:
+        description: PEP 735 dependency groups that should be installed for testing
+        required: false
+        default: ''
+        type: string
       test_extras:
         description: Any extras_requires modifier that should be used to install the package for testing
         required: false
@@ -118,8 +123,9 @@ jobs:
         with:
           apt: ${{ inputs.libraries }}
       - id: build
-        uses: OpenAstronomy/build-python-dist@bbb0e1c5b132893999ea56d77bd4b526e0097c7d  # v1.0.1
+        uses: OpenAstronomy/build-python-dist@9a4b2bd6bda5c48ef3c12b53504ee2263ed032e3  # v1.1.0
         with:
+          test_groups: ${{ inputs.test_groups }}
           test_extras: ${{ inputs.test_extras }}
           test_command: ${{ inputs.test_command }}
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -17,13 +17,15 @@ jobs:
   release_default:
     uses: ./.github/workflows/publish.yml
     with:
-      test_extras: test
+      test_groups: test, concurrency
+      test_extras: recommended
       test_command: pytest --pyargs test_package
       timeout-minutes: 30
   release:
     uses: ./.github/workflows/publish.yml
     with:
-      test_extras: test
+      test_groups: test, concurrency
+      test_extras: recommended
       test_command: pytest --pyargs test_package
       targets: |
         - linux
@@ -41,6 +43,7 @@ jobs:
   release_sdist_only:
     uses: ./.github/workflows/publish.yml
     with:
-      test_extras: test
+      test_groups: test, concurrency
+      test_extras: recommended
       test_command: pytest --pyargs test_package
       targets: ''

--- a/.github/workflows/test_publish_pure_python.yml
+++ b/.github/workflows/test_publish_pure_python.yml
@@ -17,7 +17,8 @@ jobs:
   release:
     uses: ./.github/workflows/publish_pure_python.yml
     with:
-      test_extras: test
+      test_groups: test, concurrency
+      test_extras: recommended
       test_command: pytest --pyargs test_package
       timeout-minutes: 5
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ jobs:
   publish:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
     with:
-      test_extras: test
+      test_groups: test
+      test_extras: recommended
       test_command: pytest --pyargs test_package
       targets: |
         - linux
@@ -60,7 +61,8 @@ jobs:
   publish:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
-      test_extras: test
+      test_groups: test
+      test_extras: recommended
       test_command: pytest --pyargs test_package
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/docs/source/publish.rst
+++ b/docs/source/publish.rst
@@ -10,7 +10,8 @@ platform-dependent wheels.
      publish:
        uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
        with:
-         test_extras: test
+         test_groups: test, concurrency
+         test_extras: recommended
          test_command: pytest --pyargs test_package
          targets: |
            - linux
@@ -77,6 +78,11 @@ sdist-runs-on
 
 Choose an alternative image for the runner to use for building and
 testing the source distribution. By default, this is ``ubuntu-latest``.
+
+test_groups
+^^^^^^^^^^^
+
+Comma-separated, PEP 735 dependency groups that should be installed for testing.
 
 test_extras
 ^^^^^^^^^^^

--- a/docs/source/publish_pure_python.rst
+++ b/docs/source/publish_pure_python.rst
@@ -11,7 +11,8 @@ source distribution are build, tested and published instead.
      publish:
        uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
        with:
-         test_extras: test
+         test_groups: test, concurrency
+         test_extras: recommended
          test_command: pytest --pyargs test_package
        secrets:
          pypi_token: ${{ secrets.pypi_token }}
@@ -25,6 +26,11 @@ runs-on
 Choose an alternative image for the runner to use for building and
 testing the source distribution and wheel. By default, this is
 ``ubuntu-latest``.
+
+test_groups
+^^^^^^^^^^^
+
+Comma-separated, PEP 735 dependency groups that should be installed for testing.
 
 test_extras
 ^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,36 @@
 [build-system]
-requires = ["setuptools", "wheel"]
-build-backend = 'setuptools.build_meta'
+requires = ["setuptools>=61.2"]
+build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel.linux]
 environment-pass = ["GITHUB_WORKFLOW"]
+
+[project]
+name = "test-package"
+dynamic = ["version"]
+
+[project.optional-dependencies]
+recommended = [
+    "boto3",
+    "urllib3",
+]
+
+[dependency-groups]
+concurrency = [
+    {include-group = "test"},
+    "pytest-repeat>=0.9.3",
+    "pytest-run-parallel>=0.4.4",
+]
+test = [
+    "hypothesis>=6.113.0",
+    "pytest>=8.3.5",
+]
+
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools.packages]
+find = {namespaces = false}
 
 [tool.ruff]
 line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,2 @@
-[metadata]
-name = test-package
-
-[options]
-packages = find:
-
-[options.extras_require]
-test =
-    pytest
-
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
This will require https://github.com/OpenAstronomy/build-python-dist/pull/21