### PR TITLE
MNT: upgrade windows image (2019->2022)

### DIFF
--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -27,7 +27,7 @@ jobs:
         - macos: py39-inputs-macos
         - windows: py310-inputs-windows
           toxargs: '-v'
-          runs-on: windows-2019
+          runs-on: windows-2022
 
         - linux: py312-inputs-conda
         - macos: py312-inputs-conda

--- a/docs/source/tox.rst
+++ b/docs/source/tox.rst
@@ -359,7 +359,7 @@ It can be defined globally:
      runs-on: |
        linux: ubuntu-18.04
        macos: macos-10.15
-       windows: windows-2019
+       windows: windows-2022
 
 .. code:: yaml
 
@@ -380,7 +380,7 @@ be valid YAML.)
    with:
      envs: |
        - windows: py39
-         runs-on: windows-2019
+         runs-on: windows-2022
 
 default_python
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
the `windows-2019` image is discontinued.
xref https://github.com/actions/runner-images/issues/12045