### PR TITLE
MNT: pre-commit house cleaning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,6 @@ repos:
           - "--in-place"
           - "--remove-all-unused-imports"
           - "--remove-unused-variable"
-  - repo: https://github.com/PyCQA/isort
-    rev: 7.0.0
-    hooks:
-      - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ find = {namespaces = false}
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
+extend-select = [
+    "I", # isort
+]


### PR DESCRIPTION
- **MNT: avoid deprecated pre-commit hook id for ruff**
- **MNT: drop isort as a pre-commit hook (replaced with ruff)**
