### PR TITLE
FEAT: re-export cibuildwheel's markdown summary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,10 @@ on:
         required: false
         default: ''
         type: string
+    outputs:
+      cibw_summary:
+        description: markdown step summary from cibuildwheel
+        value: jobs.build_wheels.outputs.cibw_step_summary
     secrets:
       pypi_token:
         required: false
@@ -141,6 +145,8 @@ jobs:
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{fromJSON(needs.targets.outputs.matrix)}}
+    outputs:
+      cibw_summary: ${{ steps.cibw.outputs.step_summary }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -163,6 +169,7 @@ jobs:
         run: |
           echo "space_sep_groups=$( python -c "print('${{ inputs.test_groups }}'.replace(',', ' '))" )" >> "$GITHUB_ENV"
       - name: Configure cibuildwheel
+        id: cibw
         shell: bash
         run: |
           if [ -n "${{ inputs.test_extras }}" ];

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -48,3 +48,10 @@ jobs:
       test_extras: recommended
       test_command: pytest --pyargs test_package
       targets: ''
+  re-export-cibw-summary:
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${STEPS_PUBLISH_OUTPUTS_CIBW_SUMMARY} >> "$GITHUB_STEP_SUMMARY"
+        env:
+          STEPS_PUBLISH_OUTPUTS_CIBW_SUMMARY: ${{ needs.release.outputs.cibw_summary }}


### PR DESCRIPTION
cibuildwheel 3.x has a really nice feature to summaries its output in markdown.
This re-exposes the summary so it's reusable downstream.
It's a bit non-ideal that users need to do extra work to benefit from it, I'd prefer if it was done automatically but I haven't found a way to do that. For now, opening as a draft, as it's missing extra documentation, but I want to make sure I have the best solution before I write it down.