### PR TITLE
MNT: rework local pre-commit hook as a python hook (instead of system)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: encode-scripts
         name: encode scripts in workflows
-        language: system
-        entry: python update_scripts_in_yml.py
+        language: python
+        entry: ./update_scripts_in_yml.py
         always_run: true
         pass_filenames: false

--- a/update_scripts_in_yml.py
+++ b/update_scripts_in_yml.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import os
 from base64 import b64encode
 


### PR DESCRIPTION
I noticed a while ago that this hook didn't work on my system (because I don't have a generally available `python` interpreter), but I finally took a minute to fix it.