### PR TITLE
FEAT: ensure uv is always available from cibuildwheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -202,6 +202,7 @@ jobs:
         uses: pypa/cibuildwheel@63fd63b352a9a8bdcc24791c9dbee952ee9a8abc # v3.3.0
         with:
           output-dir: dist
+          extras: uv
         env:
           CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
           CIBW_ARCHS: ${{ matrix.CIBW_ARCHS }}


### PR DESCRIPTION
leverage a new feature from cibuildwheel 3.3.0 so that uv is unconditionally available. This allows users of this workflow to leverage `build-frontend=build[uv]` and possibly `build-frontend=uv` in the future

xref: https://github.com/pypa/cibuildwheel/pull/2322

