### PR TITLE
add `save_artifact` option to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,8 @@ on:
         required: false
         default: 'ubuntu-latest'
         type: string
-      upload_artifact:
-        description: Upload the built wheels as artifacts
+      save_artifact:
+        description: Upload the built wheels as github artifacts
         required: false
         default: false
         type: boolean
@@ -212,7 +212,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.CIBW_ARCHS }}
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: |
-          needs.targets.outputs.upload_to_pypi == 'true' || inputs.upload_to_anaconda || inputs.upload_artifact
+          needs.targets.outputs.upload_to_pypi == 'true' || inputs.upload_to_anaconda || inputs.save_artifact
         with:
           name: "dist-${{ matrix.artifact-name }}"
           path: dist/*
@@ -257,7 +257,7 @@ jobs:
           python-version: '3.12'
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: |
-          needs.targets.outputs.upload_to_pypi == 'true' || inputs.upload_to_anaconda || inputs.upload_artifact
+          needs.targets.outputs.upload_to_pypi == 'true' || inputs.upload_to_anaconda || inputs.save_artifact
         with:
           name: dist-sdist
           path: dist/*

--- a/docs/source/publish.rst
+++ b/docs/source/publish.rst
@@ -173,11 +173,11 @@ repository_url
 
 The PyPI repository URL to use. Default is the main PyPI repository.
 
-upload_artifact
-^^^^^^^^^^^^^^^
+save_artifact
+^^^^^^^^^^^^^
 
-Whether to upload the wheels as github artifacts. The default is to not
-upload (unless ``upload_to_anaconda`` or ``upload_to_pypi`` is enabled).
+Whether to save/upload the wheels as github artifacts. The default is to not
+save (unless ``upload_to_anaconda`` or ``upload_to_pypi`` is enabled).
 
 upload_to_anaconda
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add an `save_artifact` option to the publish workflow.

This would be useful for:
- testing abi3 compatibility (where a follow-up job can download the artifacts and test them for abi3 compatibility)
- testing built wheels (where a user can download the produced artifact for local testing)

Here's an example of the feature in use:
https://github.com/spacetelescope/stsci.imagestats/actions/runs/20576408229/job/59094261927?pr=85
and a follow-up job that tests the wheels for abi3 compatibility:
https://github.com/spacetelescope/stsci.imagestats/actions/runs/20576408229/job/59094356347?pr=85