### PR TITLE
Do not explicitly specify uv version in calls to setup-uv

### DIFF
--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -26,6 +26,8 @@ jobs:
     uses: ./.github/workflows/tox.yml
     with:
       envs: |
+        - linux: py314-inputs-linux
+          python-version: 3.14.5
         - linux: py312-inputs-linux
         - macos: py311-inputs-macos
         - macos: py39-inputs-macos

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -155,7 +155,6 @@ jobs:
     steps:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # 8.1.0
         with:
-          version: "0.10.6"
           enable-cache: false
           ignore-empty-workdir: "true"
       - if: inputs.fill
@@ -240,7 +239,6 @@ jobs:
         if: ${{ matrix.conda != 'true' }}
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # 8.1.0
         with:
-          version: "0.10.6"
           python-version: ${{ matrix.python_version }}
           activate-environment: "true"
           ignore-empty-workdir: "true"


### PR DESCRIPTION
I'm not entirely sure why these versions were here, I don't think we want to pin it, latest should be fine?