### PR TITLE
Add option to expect tox to fail

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -202,6 +202,7 @@ jobs:
     needs: [envs]
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
+    continue-on-error: true
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix: ${{fromJSON(needs.envs.outputs.matrix)}}


### PR DESCRIPTION
I think this feature is mostly going to be useful for testing the workflows themselves, but I guess you never know.