### PR TITLE
fix bug in Python version glob expansion (passing incorrect repository URL to `supported-pythons`)

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -154,8 +154,8 @@ jobs:
         id: supported-pythons
         uses: OpenAstronomy/supported-pythons@83fea1cbcd1df5494f6846152992a553def0325b # 2.0.4
         with:
-          package: ${{ job.workflow_repository }}
-          package-ref: ${{ job.workflow_sha }}
+          package: ${{ github.repository }}
+          package-ref: ${{ github.sha }}
       - id: set-outputs
         run: |  # zizmor: ignore[template-injection]
           uv run tox_matrix.py \


### PR DESCRIPTION
`supported-pythons` should be using the originating repository's URL (`github.repository`), but instead it's using `OpenAstronomy/github-actions-workflows` (`github.workflow_repository`): https://github.com/spacetelescope/jwst/actions/runs/27967972018/job/82766673179?pr=10636

this was not revealed in testing because we test inside this repository, so `github.repository` and `github.workflow_repository` are identical 😵‍💫. Next time I should do more thorough testing with a temporary branch in another repo