### PR TITLE
Specify name for job which is expected to fail

### DIFF
--- a/.github/workflows/test_tox.yml
+++ b/.github/workflows/test_tox.yml
@@ -189,6 +189,7 @@ jobs:
            posargs: --cov=test_package
          # This job should fail and print a warning
          - linux: py314-tmpdir_warning
+           name: py314-tmpdir_warning (expected failure)
            posargs: --cov=test_package
 
   test_artifact_upload:


### PR DESCRIPTION
This adds 'expected failure' to the job name for the CI job which we actually want to have fail, to avoid confusion

cc @Cadair @neutrinoceros 